### PR TITLE
chore(repo): establish engineering workflow (templates, labels, CI, inbox system)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS
+#
+# GitHub uses this file to auto-request reviews when a PR touches certain paths.
+# As a solo dev, you're the owner of everything — but wiring this up now means
+# that when you add collaborators later, the routing is already in place.
+#
+# Syntax: <pattern> <owner> [<owner> ...]
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: any file not matched by a later rule
+* @garrettcurtis92
+
+# Core engines and data model — flag these for extra care
+/LiftOS/Services/ProgressionEngine.swift   @garrettcurtis92
+/LiftOS/Services/SessionBuilder.swift      @garrettcurtis92
+/LiftOS/Models/                            @garrettcurtis92
+
+# CI / tooling
+/.github/                                  @garrettcurtis92
+/project.yml                               @garrettcurtis92

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: "🐛 Bug report"
+description: Something is broken or behaves wrong.
+title: "[Bug]: "
+labels: ["type:bug", "priority:P2-later"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. The more detail you can give, the faster it gets fixed.
+        Triage will adjust the priority label — default is P2.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug.
+      placeholder: "Rest timer stops counting when the app backgrounds..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal sequence someone else can follow to see the bug.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "Rest timer should continue in the background and notify at zero."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: "Timer pauses on background, no notification fires."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the app
+      options:
+        - workout-logging
+        - plan-builder
+        - history
+        - progress
+        - rest-timer
+        - data-model
+        - ui-polish
+        - onboarding
+        - profile
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device & iOS version
+      placeholder: "iPhone 15 Pro, iOS 18.4"
+    validations:
+      required: true
+
+  - type: input
+    id: build
+    attributes:
+      label: App build / version
+      placeholder: "0.9.2 (TestFlight build 14)"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Screenshots, video, or logs
+      description: Drag & drop or paste. Especially helpful for UI bugs.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: I can reproduce this consistently.
+          required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,29 @@
+name: "🔧 Chore"
+description: Tooling, dependencies, CI, or build system changes.
+title: "[Chore]: "
+labels: ["type:chore", "priority:P3-someday"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs to be done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now?
+      description: What triggered this? (security advisory, failing build, dev pain, etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Definition of done
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Read the contributing guide first
+    url: https://github.com/garrettcurtis92/LiftOS-2.0/blob/main/CONTRIBUTING.md
+    about: Branch naming, commit style, and workflow rules live here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,76 @@
+name: "✨ Feature request"
+description: Propose a new user-facing capability.
+title: "[Feature]: "
+labels: ["type:feature", "priority:P2-later"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Features should tie back to a clear user problem. The "Why" matters more than the "What".
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user pain this addresses.
+      placeholder: "I can't see my rest timer when the app is backgrounded, so I miss the end of rest and my next set is late..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you build? Be specific. Sketches welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about? Why is your proposal better?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the app
+      options:
+        - workout-logging
+        - plan-builder
+        - history
+        - progress
+        - rest-timer
+        - data-model
+        - ui-polish
+        - onboarding
+        - profile
+        - ai-assistant
+        - apple-watch
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know this is done? Checklist of observable behaviors.
+      value: |
+        - [ ]
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I searched existing issues and this isn't a duplicate.
+          required: true
+        - label: This aligns with the project vision in `docs/PROJECT_PLAN.md`.
+          required: false

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,0 +1,61 @@
+name: "🧹 Tech debt / refactor"
+description: Internal code quality work with no user-visible change.
+title: "[Tech debt]: "
+labels: ["type:tech-debt", "priority:P3-someday"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tech debt tickets describe code smells, design issues, or refactors.
+        They should explain the *cost* of leaving it and the *benefit* of fixing it.
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current state
+      description: What does the code look like today? Point to files/lines.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Why is this a problem?
+      description: What's the cost of leaving this? (bugs, slower dev, hard to test, etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed refactor
+      description: What would you change? Rough shape is fine.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the app
+      options:
+        - workout-logging
+        - plan-builder
+        - history
+        - progress
+        - rest-timer
+        - data-model
+        - ui-polish
+        - onboarding
+        - profile
+        - tooling
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk / blast radius
+      description: What could go wrong during the refactor? What tests cover this?
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!--
+Thanks for the PR! Fill this out so future-you (and any reviewers) can
+understand the change in 60 seconds.
+-->
+
+## What
+
+<!-- One or two sentences: what does this PR do? -->
+
+## Why
+
+<!-- Link the issue. If there isn't one, open one first. -->
+
+Closes #
+
+## How
+
+<!-- Brief overview of the approach. Highlight any tricky bits, trade-offs, or
+     things reviewers should look at carefully. -->
+
+## Screenshots / screen recordings
+
+<!-- For any user-facing change, drop a before/after image or a short screen
+     recording. SwiftUI changes without a screenshot will be sent back. -->
+
+## Testing
+
+<!-- What did you do to verify this works? Check all that apply. -->
+
+- [ ] Built and ran on **physical device** (required for anything touching haptics, timers, notifications)
+- [ ] Built and ran in Simulator
+- [ ] Walked through the relevant manual test from `docs/PROJECT_PLAN.md`
+- [ ] Added / updated unit tests where it made sense
+- [ ] Tested in **Dark Mode**
+- [ ] Tested with **Dynamic Type** at XL (accessibility)
+
+## Risk
+
+<!-- What could go wrong? Any migrations, data model changes, or anything
+     that could affect existing user data? -->
+
+- [ ] Touches data model / SwiftData schema
+- [ ] Touches `ProgressionEngine` or other core logic
+- [ ] Touches something used inside an active workout (high blast radius)
+- [ ] Pure UI / polish (low risk)
+
+## Checklist
+
+- [ ] Branch name follows convention (`feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`, `test/`)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `xcodebuild` passes locally
+- [ ] No `print`/`dump` debug statements left in
+- [ ] No hardcoded colors or spacing (use `LiftTheme`)

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,33 @@
+[
+  { "name": "type:bug",         "color": "d73a4a", "description": "Something is broken or behaves wrong" },
+  { "name": "type:feature",     "color": "0e8a16", "description": "New user-facing capability" },
+  { "name": "type:enhancement", "color": "a2eeef", "description": "Improvement to something that already exists" },
+  { "name": "type:tech-debt",   "color": "fbca04", "description": "Code quality / refactor with no user-visible change" },
+  { "name": "type:chore",       "color": "c5def5", "description": "Tooling, dependencies, CI, docs" },
+
+  { "name": "priority:P0-now",     "color": "b60205", "description": "Drop everything. Prod broken or data at risk" },
+  { "name": "priority:P1-soon",    "color": "d93f0b", "description": "Important, next up" },
+  { "name": "priority:P2-later",   "color": "fbca04", "description": "Planned but not urgent (default for new issues)" },
+  { "name": "priority:P3-someday", "color": "cccccc", "description": "Nice to have. Backlog" },
+
+  { "name": "area:workout-logging", "color": "1d76db", "description": "Active workout flow, set logging, rest timer UI" },
+  { "name": "area:plan-builder",    "color": "1d76db", "description": "Creating / editing plans, weeks, routines" },
+  { "name": "area:history",         "color": "1d76db", "description": "History tab, past sessions, calendar heatmap" },
+  { "name": "area:progress",        "color": "1d76db", "description": "Progress charts, PRs, dashboards" },
+  { "name": "area:rest-timer",      "color": "1d76db", "description": "Rest timer logic, notifications, Live Activity" },
+  { "name": "area:data-model",      "color": "1d76db", "description": "SwiftData schema, migrations, persistence" },
+  { "name": "area:ui-polish",       "color": "1d76db", "description": "Haptics, animations, theme, micro-interactions" },
+  { "name": "area:onboarding",      "color": "1d76db", "description": "First-launch flow, empty states, Sign in with Apple" },
+  { "name": "area:profile",         "color": "1d76db", "description": "Profile tab, settings, user preferences" },
+  { "name": "area:ai-assistant",    "color": "1d76db", "description": "Claude-powered plan generation, substitutions" },
+  { "name": "area:apple-watch",     "color": "1d76db", "description": "Apple Watch companion app" },
+  { "name": "area:tooling",         "color": "1d76db", "description": "Xcode project, build, CI, scripts" },
+
+  { "name": "status:needs-triage", "color": "ededed", "description": "Not yet reviewed / prioritized" },
+  { "name": "status:blocked",      "color": "000000", "description": "Waiting on an external dependency or decision" },
+  { "name": "status:in-progress",  "color": "0e8a16", "description": "Actively being worked on" },
+  { "name": "status:on-hold",      "color": "cccccc", "description": "Paused intentionally" },
+
+  { "name": "good first task", "color": "7057ff", "description": "Small, self-contained — a good warmup ticket" },
+  { "name": "discussion",      "color": "d4c5f9", "description": "Needs a decision before work begins" }
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+# Runs on every PR targeting main, plus pushes to main itself.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel older in-flight runs of this workflow for the same ref
+# (e.g. if you push a new commit to a PR, the old CI run stops).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (iOS Simulator)
+    runs-on: macos-15
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        # Pin to an Xcode that ships Swift 6.3 / iOS 17+ SDK.
+        # Adjust this when GitHub's macOS runners add a newer Xcode image.
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Show Xcode & Swift versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Resolve package dependencies
+        run: |
+          xcodebuild \
+            -resolvePackageDependencies \
+            -project AdaptOS.xcodeproj \
+            -scheme LiftOS
+
+      - name: Build for iOS Simulator
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project AdaptOS.xcodeproj \
+            -scheme LiftOS \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            clean build \
+            CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions || \
+          xcodebuild \
+            -project AdaptOS.xcodeproj \
+            -scheme LiftOS \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            clean build \
+            CODE_SIGNING_ALLOWED=NO
+
+  test:
+    name: Unit tests
+    runs-on: macos-15
+    timeout-minutes: 25
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+
+      - name: Run tests
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project AdaptOS.xcodeproj \
+            -scheme LiftOS \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            test \
+            CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions || \
+          xcodebuild \
+            -project AdaptOS.xcodeproj \
+            -scheme LiftOS \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -skipPackagePluginValidation \
+            test \
+            CODE_SIGNING_ALLOWED=NO

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,189 @@
+# Contributing to LiftOS
+
+This is the single source of truth for how work flows through this repo.
+If you're ever unsure, check here first.
+
+> **Status:** Solo project (Garrett). Written as if onboarding a teammate, because
+> future-you *is* a teammate, and because this is what real engineering teams do.
+
+---
+
+## TL;DR — The 90-second version
+
+1. Every change starts with a **GitHub Issue**. No issue, no work.
+2. Every issue gets a **branch** whose name encodes type and slug: `feat/live-activity-timer`.
+3. Every branch lands on `main` through a **Pull Request** that links the issue.
+4. `main` is always shippable. A green PR can become a build at any time.
+5. If production is broken, a **hotfix branch** jumps the queue: `fix/hotfix-crash-on-launch`.
+
+---
+
+## Branching model: GitHub Flow (with hotfixes)
+
+We use GitHub Flow, not Git Flow. One long-lived branch (`main`) and many short-lived
+feature/fix branches. Git Flow's `develop` branch adds complexity we don't need as a solo dev.
+
+```
+main ─────●─────●─────●─────●─────●──────> (always shippable)
+           \       \     \       \
+            feat    fix   chore   feat/hotfix
+```
+
+### Branch naming
+
+Format: `<type>/<short-kebab-slug>`
+
+| Prefix  | When to use                                          | Example                              |
+| ------- | ---------------------------------------------------- | ------------------------------------ |
+| `feat/` | New user-facing feature                              | `feat/calendar-heatmap`              |
+| `fix/`  | Bug fix (non-urgent)                                 | `fix/rest-timer-resumes-on-resume`   |
+| `hotfix/` | Urgent fix going to a released build               | `hotfix/crash-on-workout-start`      |
+| `chore/`| Tooling, deps, refactors with no user-facing effect  | `chore/theme-color-consolidation`    |
+| `docs/` | Documentation only                                   | `docs/add-branching-diagram`         |
+| `test/` | Adding or fixing tests                               | `test/progression-engine-coverage`   |
+
+**Rules:**
+- Always branch from **up-to-date** `main` (`git pull --rebase origin main` first).
+- Keep branches short-lived — aim to merge within a few days.
+- One concern per branch. If scope creeps, open a new issue + branch.
+
+---
+
+## Commit messages: Conventional Commits
+
+Format: `<type>(<scope>): <subject>`
+
+| Type       | Meaning                                      |
+| ---------- | -------------------------------------------- |
+| `feat`     | New feature                                  |
+| `fix`      | Bug fix                                      |
+| `chore`    | Tooling / housekeeping                       |
+| `refactor` | Code change that neither adds nor fixes      |
+| `docs`     | Documentation only                           |
+| `test`     | Adding or fixing tests                       |
+| `perf`     | Performance improvement                      |
+| `style`    | Formatting, whitespace (no code change)      |
+
+Scope is optional but encouraged. Examples:
+
+```
+feat(history): add calendar heatmap for workout streaks
+fix(timer): prevent rest timer skipping when app backgrounds
+chore(deps): bump swift tools version to 6.3
+refactor(theme): consolidate hardcoded colors into LiftTheme
+```
+
+**Why this matters:** Conventional Commits make the git history greppable, enable
+auto-generated changelogs later, and are the de-facto standard at most
+modern engineering teams. Great muscle memory to build now.
+
+---
+
+## The workflow, step-by-step
+
+### 1. Pick (or open) an issue
+
+- Look at the Project board → `This Week` column.
+- If the work isn't captured, open a new issue using the correct template.
+- Assign yourself and move it to **In Progress**.
+
+### 2. Create a branch
+
+```bash
+git checkout main
+git pull --rebase origin main
+git checkout -b feat/calendar-heatmap
+```
+
+### 3. Commit in small, logical chunks
+
+```bash
+git add <files>
+git commit -m "feat(history): scaffold CalendarHeatmapView"
+```
+
+Commit more often than feels necessary. Each commit should leave the app in
+a working state when possible.
+
+### 4. Push and open a PR
+
+```bash
+git push -u origin feat/calendar-heatmap
+gh pr create --fill --assignee @me
+```
+
+Fill out the PR template. **Always link the issue** with `Closes #NN` —
+this auto-closes the issue when the PR merges.
+
+### 5. Wait for CI
+
+Every PR runs `xcodebuild` against the project. Red = fix before merging.
+
+### 6. Merge
+
+Use **Squash and merge** for feature branches so `main` stays clean:
+one issue → one commit on `main`.
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+### 7. Deploy
+
+For this project, "deploy" = cut a TestFlight build from `main`.
+Tag releases: `git tag v0.9.0 && git push --tags`.
+
+---
+
+## Hotfix workflow
+
+When a released version is broken:
+
+1. Branch from the **tag** of the broken release (not `main` — `main` may be ahead).
+   ```bash
+   git checkout -b hotfix/crash-on-workout-start v0.9.0
+   ```
+2. Fix, commit, push.
+3. Open a PR **into `main`**, labeled `priority:P0-now`.
+4. After merge, cut a patch release: `v0.9.1`.
+5. The fix will naturally flow into the next feature release via `main`.
+
+---
+
+## Issue types & priority
+
+| Label         | Meaning                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| `type:bug`    | Something is broken or behaves wrong                                 |
+| `type:feature`| New user-facing capability                                           |
+| `type:enhancement` | Improvement to something that already exists                    |
+| `type:tech-debt`   | Code quality / refactor with no user-visible change             |
+| `type:chore`  | Tooling, deps, CI, docs                                              |
+| `priority:P0-now`  | Drop everything. Prod is broken or data is at risk              |
+| `priority:P1-soon` | Important, next up                                              |
+| `priority:P2-later`| Planned but not urgent                                          |
+| `priority:P3-someday` | Nice to have. Could sit in the backlog forever               |
+
+Area labels (`area:workout-logging`, `area:plan-builder`, etc.) help you
+filter the backlog by part of the app.
+
+---
+
+## What "Done" means
+
+A ticket is **Done** when:
+
+- [ ] Code is merged to `main`
+- [ ] CI is green on `main`
+- [ ] Manual test (the relevant Phase 6 testing step from `PROJECT_PLAN.md`) passes
+- [ ] The issue is closed (auto-closed via `Closes #NN` in the PR)
+- [ ] If user-visible: it works on a physical device, not just Simulator
+
+---
+
+## Questions this doc answers so you don't have to remember
+
+- **"What should I name this branch?"** → See the Branch Naming table above.
+- **"How do I write this commit message?"** → Conventional Commits section.
+- **"It's 11pm and the app crashes on launch — what do I do?"** → Hotfix workflow.
+- **"How does a bug I found become a fix?"** → Open an issue → branch → PR → merge.

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,95 @@
+# Branching strategy (visual)
+
+Short reference card. For the full playbook, see [`/CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+---
+
+## The normal flow — GitHub Flow
+
+```
+                                              squash & merge
+main ──────●─────────●─────────────●──────────────●────────────●──>
+            \                       \              \
+             \                       \              \
+              └─feat/calendar-heatmap ┘              └─fix/rest-timer-background
+                 │   │   │                              │   │
+                 │   │   └── commit N                   │   └── commit 2
+                 │   └────── commit 2                   └────── commit 1
+                 └────────── commit 1
+```
+
+**Rules of the road:**
+
+- `main` is **always** shippable. Never commit directly.
+- Branch from `main`. Merge back via Pull Request.
+- Squash-merge feature branches so `main` reads as one commit per issue.
+- Delete the branch immediately after merge (`gh pr merge --squash --delete-branch`).
+
+---
+
+## The hotfix flow
+
+When a **released build** is broken, you don't want to ship whatever half-done feature
+is sitting on `main`. You want to ship just the fix.
+
+```
+                                                      cherry-free
+main ──●─(v0.9.0 tag)─●─────●─────●───────────────●──merge──────●──>
+        \                                          \            ^
+         \                                          \           │
+          └── hotfix/crash-on-workout-start ────────┘           │
+                                                                │
+tag v0.9.0 ──┐                                                  │
+              └── hotfix branches from here ─────────────────> PR into main
+                                                                +
+                                                                tag v0.9.1, build release
+```
+
+**Steps:**
+
+1. `git checkout -b hotfix/<slug> v0.9.0`  *(branch from the broken release's tag)*
+2. Fix, commit, push.
+3. Open PR into `main` with label `priority:P0-now`.
+4. After merge, tag the patch: `git tag v0.9.1 && git push --tags`.
+5. Cut a new TestFlight build from that tag.
+
+Because `main` already has the new features in flight, you don't want to release `main` yet
+— you release the tag. The fix flows into the next feature release naturally through `main`.
+
+---
+
+## Decision tree: which branch prefix?
+
+```
+Is this breaking something users have already seen (released build)?
+├── YES ──> hotfix/<slug>   (branch from the release tag)
+└── NO
+    │
+    Is this a new user-facing capability?
+    ├── YES ──> feat/<slug>
+    └── NO
+        │
+        Is this fixing incorrect behavior (non-urgent)?
+        ├── YES ──> fix/<slug>
+        └── NO
+            │
+            Is this docs-only?
+            ├── YES ──> docs/<slug>
+            │
+            Is this tests-only?
+            ├── YES ──> test/<slug>
+            │
+            Otherwise ───> chore/<slug>
+```
+
+---
+
+## Why GitHub Flow over Git Flow?
+
+Git Flow adds a long-lived `develop` branch plus `release/*` and `hotfix/*` branches.
+It made sense when shipping was a big scheduled event with a QA team.
+
+As a solo dev shipping to TestFlight whenever something is ready, Git Flow's
+extra branches are just bookkeeping with no payoff. GitHub Flow is what most
+modern SaaS teams actually use. If you add teammates later, this scales fine
+with branch protection rules and required reviews.

--- a/docs/INBOX_SYSTEM.md
+++ b/docs/INBOX_SYSTEM.md
@@ -1,0 +1,198 @@
+# The Inbox System
+
+A zero-friction pipeline from "ugh, this is broken" (mid-workout) to a well-structured
+GitHub issue (later, with Claude's help).
+
+---
+
+## The idea
+
+Two rails:
+
+1. **Capture rail** — fast, dumb, voice-driven. Just get the thought out of your head.
+2. **Processing rail** — slow, thoughtful, happens when you're at your desk with Claude.
+
+Never mix them. Trying to write a "proper" bug report mid-set is how ideas get lost.
+
+```
+iPhone                iCloud Drive              Mac / Cowork             GitHub
+─────                 ─────────────             ────────────             ──────
+ Siri → Shortcut ──>  LiftOS/inbox.md  ─┐
+                                         │
+ Tap home icon ────>  LiftOS/inbox.md  ──┤──>  Claude reads file  ──>  gh issue create
+                                         │        (in Cowork)                │
+                                        sync                                 ▼
+                                         │                            issues in backlog
+                                         ▼
+                                 Mac also sees file
+                                (same inbox.md everywhere)
+```
+
+---
+
+## Part 1 — One-time Mac setup (2 minutes)
+
+Open Terminal on your Mac and run:
+
+```bash
+# Create the inbox folder inside your iCloud Drive
+ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
+mkdir -p "$ICLOUD/LiftOS"
+
+# Seed the two files (inbox = unread, archive = processed)
+cat > "$ICLOUD/LiftOS/inbox.md" <<'EOF'
+# LiftOS Inbox
+
+Raw capture. Don't worry about structure — just dump.
+Claude will read this file in Cowork, ask clarifying questions,
+and turn each entry into a properly-structured GitHub issue.
+
+---
+
+EOF
+
+cat > "$ICLOUD/LiftOS/inbox-archive.md" <<'EOF'
+# LiftOS Inbox — Archive
+
+Processed entries, by date. Kept for reference so you can see the
+original raw thought vs. the final issue.
+
+---
+
+EOF
+
+echo "Done. Files created at: $ICLOUD/LiftOS/"
+```
+
+**Verify in Finder:** `Cmd+Shift+G` → paste `~/Library/Mobile Documents/com~apple~CloudDocs/LiftOS/` → you should see both files.
+
+You can also find it in the Files app on iPhone under **iCloud Drive → LiftOS**.
+
+---
+
+## Part 2 — Build the Siri Shortcut on your iPhone (10 minutes, once)
+
+The goal: say "Hey Siri, log LiftOS" → dictation appears → you speak → the Shortcut
+appends a timestamped entry to `inbox.md`.
+
+### Steps
+
+1. Open the **Shortcuts** app on iPhone (pre-installed).
+2. Tap **+** (top right) to create a new Shortcut.
+3. Tap the name at the top and call it **"Log LiftOS"**.
+4. Add actions in order — tap **+ Add Action** between each:
+
+   | # | Action (search this in the action picker) | Configuration |
+   |---|-------------------------------------------|---------------|
+   | 1 | **Dictate Text** | Language: English (US). Stop Listening: **After Pause** (or **After 30 seconds** if you tend to think mid-sentence). |
+   | 2 | **Get Current Date** | *(no config needed)* |
+   | 3 | **Format Date** | Tap the date variable → Format: **ISO 8601**. Or use Custom: `yyyy-MM-dd HH:mm`. |
+   | 4 | **Text** | Type this exactly (with a blank line above/below to make it a clean entry): <br><pre>- [ ] [Formatted Date] &mdash; [Dictated Text]<br><br></pre>Where `[Formatted Date]` and `[Dictated Text]` are variables you insert by tapping the text field → **Select Variable**. |
+   | 5 | **Get File** | Service: **iCloud Drive**. Path: `LiftOS/inbox.md`. Turn OFF "Show Document Picker." |
+   | 6 | **Combine Text** | Combine: *the file from step 5* + *the text from step 4*. Separator: *None*. <br>**Important:** file first, new text second — so new entries append to the bottom. |
+   | 7 | **Save File** | Service: **iCloud Drive**. Path: `LiftOS/inbox.md`. Turn OFF "Ask Where to Save". Turn ON **Overwrite**. |
+
+5. Tap **Done** (top right) to save.
+6. Test: tap the Shortcut's tile. It should ask for Microphone, Files, and iCloud Drive access the first time — grant all three.
+7. Set up Siri: hold down the Shortcut tile → **Add to Siri** → record yourself saying "Log LiftOS".
+8. **Bonus:** Long-press the Shortcut tile → **Details → Add to Home Screen** so you can tap an icon too.
+
+### First test
+
+- Say: **"Hey Siri, log LiftOS"**
+- Siri shows a dictation box → say something like *"testing the inbox system"*
+- Open Files app → iCloud Drive → LiftOS → inbox.md → you should see your entry at the bottom.
+
+---
+
+## Part 3 — How you use it day-to-day
+
+### Capture (anytime, anywhere)
+
+- Mid-workout: *"Hey Siri, log LiftOS"* → speak → done.
+- Phone in hand: tap the home screen icon → speak.
+- Driving: Siri via CarPlay → speak.
+
+Don't edit. Don't structure. Don't worry about duplicates. **Just capture.**
+
+### Process (whenever you open Cowork)
+
+Open Cowork. Say (or type):
+
+> **"Process my inbox."**
+
+Claude will:
+
+1. Read `~/Library/Mobile Documents/com~apple~CloudDocs/LiftOS/inbox.md`
+2. Parse each entry (the `- [ ]` bullets)
+3. For each one, do one of:
+   - **Clear cases** (obvious bug / feature): propose an issue title + labels + body, ask "create this?"
+   - **Ambiguous cases**: ask 1-2 clarifying questions first
+   - **Duplicates of existing issues**: point out the existing issue, ask whether to add a comment or close
+4. After each entry: run `gh issue create` (or give you the exact command if you want to run it yourself)
+5. Move the processed entry to `inbox-archive.md` with the created issue number, then clear it from `inbox.md`
+
+### Example
+
+**Inbox:**
+```
+- [ ] 2026-04-20 09:41 — rest timer dies when i background the app no notification
+- [ ] 2026-04-20 10:15 — would be cool if the home tab showed yesterdays volume
+- [ ] 2026-04-20 18:03 — add protien tracking maybe??
+```
+
+**In Cowork:**
+
+> **You:** Process my inbox.
+>
+> **Claude:** Found 3 entries.
+>
+> **#1** is a bug report about the rest timer — matches an issue we already seeded from your PROJECT_PLAN (issue #N: "Rest timer local notification when app backgrounded"). I'll add a comment noting you hit this in the wild, and archive the entry. OK?
+>
+> **#2** is a feature idea. Proposed issue:
+> - Title: `[Feature]: Show yesterday's total volume on Home tab`
+> - Labels: `type:feature`, `priority:P2-later`, `area:ui-polish`
+> - Area dropdown: I'm guessing `ui-polish` — could also be `progress`. Which fits better?
+>
+> **#3** is scope-adjacent. Protein tracking is food/nutrition — that's arguably a separate app, not LiftOS. Want me to:
+> (a) open a "discussion" issue to capture the thought for later debate,
+> (b) archive it without an issue, or
+> (c) something else?
+
+---
+
+## Part 4 — Connecting Cowork to the inbox file
+
+Because the inbox lives in iCloud Drive (not inside the repo), Claude needs a way
+to read it. You have three options:
+
+1. **Point Cowork's workspace folder at iCloud temporarily.** When you want to process,
+   switch the Cowork workspace to `~/Library/Mobile Documents/com~apple~CloudDocs/LiftOS/`.
+   Claude reads + archives directly. When done, switch back to the repo. *(Cleanest,
+   Claude can write to the files.)*
+
+2. **Copy-paste into chat.** Open `inbox.md` on your Mac, copy all, paste into Cowork
+   with "process this." Claude reads, you archive manually afterward.
+   *(Works without switching workspaces.)*
+
+3. **Symlink inbox.md into the repo** (advanced):
+   ```bash
+   ln -s "$HOME/Library/Mobile Documents/com~apple~CloudDocs/LiftOS/inbox.md" \
+         "$HOME/path/to/LiftOS-2.0/.inbox.md"
+   echo ".inbox.md" >> .gitignore
+   echo ".inbox-archive.md" >> .gitignore  # if you also symlink the archive
+   ```
+   Then Claude reads `.inbox.md` inside the mounted repo, no workspace switching needed.
+   *(Best UX long-term, slight setup complexity.)*
+
+Start with option 2 today. Upgrade to option 1 or 3 once you're sure the capture
+habit sticks.
+
+---
+
+## Why this design?
+
+- **Separation of concerns.** Capture is fast + sloppy. Processing is slow + structured. One tool per job.
+- **Plain text.** Works forever, survives every tool migration, greppable.
+- **Human in the loop.** Claude never silently creates issues. You approve each one. This keeps your backlog signal-to-noise high.
+- **Preserves context.** The archive file keeps your raw thought next to the polished issue number, which is surprisingly useful months later when you're wondering why an issue exists.

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -1,0 +1,438 @@
+# Workflow setup runbook
+
+Run these once, from your Mac's Terminal, inside the repo root (`LiftOS-2.0`).
+This turns the files in `.github/` into a live, working GitHub workflow.
+
+**Prereqs:**
+
+- `gh` installed (`brew install gh`) and authenticated (`gh auth login`)
+- `jq` installed (`brew install jq`) — used to loop over `labels.json`
+- You're on `main` with a clean working tree
+
+> **Tip:** Run each block and watch the output. If something errors, stop and
+> read the message before continuing.
+
+---
+
+## Step 1 — Commit and push the `.github/` files
+
+Before `gh` can talk to anything, the templates need to exist on GitHub:
+
+```bash
+git status
+git add CONTRIBUTING.md .github/ docs/BRANCHING.md docs/WORKFLOW_SETUP.md
+git commit -m "chore(repo): establish engineering workflow (templates, labels, CI)"
+git push origin main
+```
+
+Refresh the repo on github.com — you should see the new **Issues** template picker
+when you click "New issue".
+
+---
+
+## Step 2 — Apply labels from `.github/labels.json`
+
+This creates every label in `labels.json`. If a label already exists with the
+same name, it updates the color and description.
+
+```bash
+# From repo root
+jq -c '.[]' .github/labels.json | while read -r row; do
+  name=$(echo "$row"    | jq -r '.name')
+  color=$(echo "$row"   | jq -r '.color')
+  desc=$(echo "$row"    | jq -r '.description')
+
+  if gh label list --limit 200 | grep -q "^${name}\b"; then
+    gh label edit "$name" --color "$color" --description "$desc"
+    echo "updated: $name"
+  else
+    gh label create "$name" --color "$color" --description "$desc"
+    echo "created: $name"
+  fi
+done
+```
+
+Verify:
+
+```bash
+gh label list --limit 200
+```
+
+You should see ~28 labels across `type:*`, `priority:*`, `area:*`, `status:*`.
+
+**Optional cleanup:** GitHub creates default labels (`bug`, `enhancement`,
+`documentation`, etc.) when the repo is made. You can delete them since we're
+using our own prefixed scheme:
+
+```bash
+for old in bug documentation duplicate enhancement "good first issue" "help wanted" invalid question wontfix; do
+  gh label delete "$old" --yes 2>/dev/null || true
+done
+```
+
+---
+
+## Step 3 — Create the Project board
+
+GitHub Projects is the Kanban board where you'll drag tickets through columns.
+
+```bash
+# Create the project (user-scoped — change --owner if using an org)
+gh project create \
+  --owner garrettcurtis92 \
+  --title "LiftOS Roadmap"
+```
+
+Copy the project number it prints (e.g. `#3`). You'll need it below.
+
+Then link it to the repo:
+
+```bash
+# Replace 3 with your project number
+PROJECT_NUMBER=3
+```
+
+Open the project in the browser to customize columns:
+
+```bash
+gh project view $PROJECT_NUMBER --owner garrettcurtis92 --web
+```
+
+In the UI:
+
+1. Add a **Status** field (if not already there) with these values:
+   - `Backlog`
+   - `This Week`
+   - `In Progress`
+   - `In Review`
+   - `Done`
+2. Switch the view to **Board** layout, grouped by Status.
+3. Save.
+
+> You can do this from the CLI too, but the UI is faster for a one-time setup.
+
+---
+
+## Step 4 — Enable branch protection on `main`
+
+This is what makes `main` "always shippable" — GitHub blocks direct pushes and
+requires PRs + green CI.
+
+```bash
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  /repos/garrettcurtis92/LiftOS-2.0/branches/main/protection \
+  -f "required_status_checks[strict]=true" \
+  -f "required_status_checks[contexts][]=Build (iOS Simulator)" \
+  -F "enforce_admins=false" \
+  -F "required_pull_request_reviews[required_approving_review_count]=0" \
+  -F "required_pull_request_reviews[dismiss_stale_reviews]=true" \
+  -F "restrictions=null" \
+  -F "allow_force_pushes=false" \
+  -F "allow_deletions=false"
+```
+
+> `enforce_admins=false` and `required_approving_review_count=0` are intentional
+> for solo dev — you can still merge your own PRs. Flip both to `true` when
+> you add teammates.
+
+---
+
+## Step 5 — Seed the initial backlog
+
+These `gh issue create` commands populate your Project board with real work
+drawn from `docs/PROJECT_PLAN.md`. Run them in order — the whole block takes
+~60 seconds.
+
+> **Note:** `gh issue create` does not yet support adding to a Project directly
+> from the CLI in one step. After creating issues, bulk-add them to the Project
+> via the UI (takes 30 seconds) or use `gh project item-add`.
+
+### Phase 7: Polish the Gaps
+
+```bash
+gh issue create \
+  --title "[Feature]: Onboarding flow for first launch" \
+  --label "type:feature,priority:P1-soon,area:onboarding" \
+  --body "$(cat <<'EOF'
+## Problem
+A first-time user lands on an empty Home tab with no guidance. Drop-off risk before
+they understand the core workflow (create plan → start workout).
+
+## Proposed solution
+A 3-screen onboarding shown on first launch:
+1. Welcome + value prop (double progression, local-only privacy)
+2. Offer "Create your first plan" → opens Plan Builder OR "Try a quick workout"
+3. Optional Sign in with Apple
+
+Dismiss forever after any action.
+
+## Acceptance criteria
+- [ ] \`OnboardingView.swift\` created, shown on first launch only
+- [ ] State persisted via \`AppStorage\`
+- [ ] Skip button available on every screen
+- [ ] Works in Dark Mode and at largest Dynamic Type size
+- [ ] Does not re-appear after dismissal, even on app relaunch
+EOF
+)"
+
+gh issue create \
+  --title "[Feature]: Calendar heatmap on History tab" \
+  --label "type:feature,priority:P1-soon,area:history" \
+  --body "$(cat <<'EOF'
+## Problem
+History tab is a flat list. Users can't see their consistency at a glance.
+
+## Proposed solution
+GitHub-style calendar heatmap showing workout intensity per day over the last
+12 weeks. Originally planned as \`CalendarHeatmapView\` in PROJECT_PLAN but never built.
+
+Intensity = total volume (sets × reps × weight) normalized to the user's weekly max.
+
+## Acceptance criteria
+- [ ] \`CalendarHeatmapView.swift\` in \`LiftOS/Views/History/\`
+- [ ] Shows last 12 weeks, 7 days tall
+- [ ] Color scale: empty / light / medium / bold (match Apple Fitness activity rings vibe)
+- [ ] Tapping a cell opens that day's session detail
+- [ ] Performance: smooth scroll with 2+ years of data
+EOF
+)"
+
+gh issue create \
+  --title "[Feature]: Progress Dashboard (weekly volume, streak, tonnage)" \
+  --label "type:feature,priority:P1-soon,area:progress" \
+  --body "$(cat <<'EOF'
+## Problem
+No single view answers "am I making progress?" right now. Individual exercise
+charts exist but no rollup.
+
+## Proposed solution
+New \`ProgressDashboardView\` tab (or section inside History) with:
+- Weekly volume chart (bar)
+- Muscle group balance (last 4 weeks)
+- Current streak
+- Total tonnage over time
+
+Uses Swift Charts, no third-party deps.
+
+## Acceptance criteria
+- [ ] New view reachable from History tab
+- [ ] All charts respect user's weight unit (lbs/kg)
+- [ ] Handles <1 week of data gracefully (no crashes, empty state)
+EOF
+)"
+
+gh issue create \
+  --title "[Feature]: Rest timer local notification when app backgrounded" \
+  --label "type:feature,priority:P1-soon,area:rest-timer" \
+  --body "$(cat <<'EOF'
+## Problem
+If you leave the app during rest (to change a song, check a text), you miss
+the timer hitting zero and either over-rest or rush back.
+
+## Proposed solution
+Schedule a \`UNUserNotification\` when the timer starts. Fire at zero.
+Cancel if the timer completes while app is foregrounded.
+
+## Acceptance criteria
+- [ ] Permission requested on first rest timer start (not on app launch)
+- [ ] Notification body shows exercise name + "Set X of Y"
+- [ ] Notification is canceled if user returns to app before zero
+- [ ] Settings toggle in Profile tab to disable the notification
+- [ ] No sound if device is on silent / focus mode
+EOF
+)"
+
+gh issue create \
+  --title "[Feature]: Rest timer Live Activity + Dynamic Island" \
+  --label "type:feature,priority:P2-later,area:rest-timer" \
+  --body "$(cat <<'EOF'
+## Problem
+Even with local notifications, the timer is invisible without opening the app.
+
+## Proposed solution
+ActivityKit Live Activity that shows the rest timer on lock screen and
+Dynamic Island. Updates in real time without needing the app open.
+
+## Acceptance criteria
+- [ ] Live Activity appears when rest timer starts
+- [ ] Lock screen view shows countdown + exercise name
+- [ ] Dynamic Island compact + expanded layouts
+- [ ] Ends when timer hits zero OR user returns to app and completes next set
+- [ ] Gracefully no-ops on devices without Dynamic Island
+EOF
+)"
+
+gh issue create \
+  --title "[Enhancement]: Empty state polish on History tab" \
+  --label "type:enhancement,priority:P3-someday,area:history,good first task" \
+  --body "$(cat <<'EOF'
+## Problem
+History empty state is generic. Doesn't help the user figure out what to do next.
+
+## Proposed solution
+Change the message based on whether an active plan exists:
+- No plan: "Create a plan to start tracking your workouts"
+- Plan exists, no workouts: "Tap Start Workout on the Today tab to log your first session"
+
+## Acceptance criteria
+- [ ] Conditional text in HistoryTab empty state
+- [ ] Primary CTA button navigates to the right tab
+EOF
+)"
+
+gh issue create \
+  --title "[Enhancement]: Loading skeleton on ExerciseProgressView" \
+  --label "type:enhancement,priority:P3-someday,area:progress,good first task" \
+  --body "$(cat <<'EOF'
+## Problem
+\`loadHistory()\` flashes an empty chart briefly on open.
+
+## Proposed solution
+Use \`.redacted(reason: .placeholder)\` on the chart and stats rows while loading.
+
+## Acceptance criteria
+- [ ] Skeleton appears for the duration of the fetch
+- [ ] Smooth fade to real data on load
+EOF
+)"
+```
+
+### Phase 8: App Store Readiness
+
+```bash
+gh issue create \
+  --title "[Tech debt]: Replace dev-time auto-wipe with versioned schema migrations" \
+  --label "type:tech-debt,priority:P0-now,area:data-model" \
+  --body "$(cat <<'EOF'
+## Current state
+\`ModelContainer+LiftOS.swift\` auto-wipes the store on incompatible schema changes.
+Safe during dev, but **ships to users = data loss**.
+
+## Why is this a problem?
+Once the app is in TestFlight with real users (including you, daily), any schema
+change without migrations nukes workout history. This blocks App Store release.
+
+## Proposed refactor
+- Convert current schema to \`VersionedSchema\` (e.g. \`LiftOSSchemaV1\`)
+- Create \`MigrationPlan\` with stages
+- Remove the auto-wipe branch
+- Add a SwiftData migration test
+
+## Risk
+HIGH — touches persistence. Blast radius = all stored data.
+Must be tested with a real populated store before shipping.
+EOF
+)"
+
+gh issue create \
+  --title "[Feature]: App icon + launch screen" \
+  --label "type:feature,priority:P1-soon,area:tooling" \
+  --body "$(cat <<'EOF'
+## Problem
+Placeholder icon and no launch screen — blocks TestFlight submission.
+
+## Proposed solution
+- Design icon at 1024×1024, export all App Store sizes via Icon Composer
+- SwiftUI launch screen with logo on system background
+
+## Acceptance criteria
+- [ ] All required icon sizes in Assets.xcassets
+- [ ] Launch screen renders correctly in light + dark mode
+- [ ] No Apple HIG violations (no text on icon, no transparency)
+EOF
+)"
+
+gh issue create \
+  --title "[Tech debt]: Unit tests for ProgressionEngine and SessionBuilder" \
+  --label "type:tech-debt,priority:P1-soon,area:workout-logging" \
+  --body "$(cat <<'EOF'
+## Current state
+Core logic (\`ProgressionEngine\`, \`SessionBuilder\`) has no unit tests. All behavior
+is verified manually through the app.
+
+## Why is this a problem?
+- Regressions in progression suggestions would silently break training plans
+- Refactors are risky without a safety net
+- CI has nothing to run
+
+## Proposed refactor
+XCTest targets covering:
+- Double progression: under range, in range, at max, deload
+- SessionBuilder: copies template data correctly, doesn't mutate source
+- Edge cases: empty rep range, missing previous session
+
+## Risk
+Low — adding tests only.
+EOF
+)"
+
+gh issue create \
+  --title "[Chore]: Privacy manifest (PrivacyInfo.xcprivacy)" \
+  --label "type:chore,priority:P1-soon,area:tooling" \
+  --body "$(cat <<'EOF'
+## What needs to be done
+Add \`PrivacyInfo.xcprivacy\` declaring:
+- SwiftData usage (NSPrivacyAccessedAPICategoryUserDefaults, etc.)
+- No tracking
+- No third-party SDKs
+
+## Why now?
+Required for App Store submission as of 2024.
+
+## Definition of done
+- [ ] PrivacyInfo.xcprivacy added to Xcode project
+- [ ] \`xcodebuild\` includes it in the built app bundle
+- [ ] Validated via \`diagnose\` in App Store Connect on first upload
+EOF
+)"
+```
+
+---
+
+## Step 6 — Add seeded issues to the Project board
+
+```bash
+# Open the Project in your browser and bulk-add open issues:
+gh project view $PROJECT_NUMBER --owner garrettcurtis92 --web
+```
+
+In the UI: click **+ Add items** → filter by `is:issue is:open repo:garrettcurtis92/LiftOS-2.0` → select all → Add.
+
+Then drag the P1 issues into `This Week`, leave P2/P3 in `Backlog`.
+
+---
+
+## Step 7 — Smoke test
+
+```bash
+# Confirm everything is wired:
+gh issue list --limit 20
+gh label list --limit 30
+gh workflow list
+```
+
+You should see:
+- ~10 open issues
+- ~28 labels
+- 1 workflow (`CI`)
+
+---
+
+## Done. What the daily workflow looks like now
+
+From this moment on, your loop is:
+
+```
+1. Pick an issue from "This Week" column → move to "In Progress"
+2. git checkout -b feat/<slug>
+3. Code, commit with Conventional Commits
+4. git push -u origin feat/<slug>
+5. gh pr create --fill
+6. Wait for green CI
+7. gh pr merge --squash --delete-branch
+8. Issue auto-closes via "Closes #NN" in PR body → moves to "Done" column
+```
+
+Repeat.


### PR DESCRIPTION
## Summary
- Adds GitHub issue templates (bug, feature, chore, tech-debt), PR template, CODEOWNERS, and CI workflow
- Introduces prefixed label scheme (type:, priority:, area:, status:) via labels.json
- Adds docs: BRANCHING.md, WORKFLOW_SETUP.md, INBOX_SYSTEM.md, and Inbox.md triage file
- Adds CONTRIBUTING.md with contribution guidelines

## Test plan
- [ ] Verify CI workflow triggers on PR
- [ ] Verify issue templates appear when creating a new issue
- [ ] Apply labels per step 3 of setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)