### PR TITLE
fix(plan-builder): eliminate blank popup in exercise picker

### DIFF
--- a/LiftOS/Views/PlanBuilder/RoutineEditorView.swift
+++ b/LiftOS/Views/PlanBuilder/RoutineEditorView.swift
@@ -11,7 +11,6 @@ struct RoutineEditorView: View {
     @State private var showSyncPrompt = false
     @State private var pendingSyncAction: (() -> Void)? = nil
     @State private var pendingExercise: Exercise? = nil
-    @State private var showExerciseConfig = false
     @State private var showEditRoutine = false
 
     private var isWeekOne: Bool {
@@ -58,11 +57,7 @@ struct RoutineEditorView: View {
                 .presentationDragIndicator(.visible)
                 .presentationCornerRadius(20)
         }
-        .sheet(isPresented: $showingExercisePicker, onDismiss: {
-            if pendingExercise != nil {
-                showExerciseConfig = true
-            }
-        }) {
+        .sheet(isPresented: $showingExercisePicker) {
             ExercisePickerView { exercise in
                 pendingExercise = exercise
                 showingExercisePicker = false
@@ -71,15 +66,14 @@ struct RoutineEditorView: View {
             .presentationDragIndicator(.visible)
             .presentationCornerRadius(20)
         }
-        .sheet(isPresented: $showExerciseConfig) {
-            if let exercise = pendingExercise {
-                ExerciseConfigSheet(exercise: exercise) { sets, repMin, repMax, weight in
-                    addExercise(exercise, sets: sets, repMin: repMin, repMax: repMax, weight: weight)
-                    pendingExercise = nil
-                }
-                .presentationDragIndicator(.visible)
-                .presentationCornerRadius(20)
+        .sheet(item: $pendingExercise) { exercise in
+            ExerciseConfigSheet(exercise: exercise) { sets, repMin, repMax, weight in
+                addExercise(exercise, sets: sets, repMin: repMin, repMax: repMax, weight: weight)
+                pendingExercise = nil
             }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+            .presentationCornerRadius(20)
         }
         .confirmationDialog(
             "Remove \(exerciseToDelete?.exercise?.name ?? "Exercise")?",


### PR DESCRIPTION
## Summary
- Replaces the fragile two-boolean sheet chaining pattern (`showExerciseConfig` + `onDismiss`) with SwiftUI's atomic `.sheet(item:)` API
- `pendingExercise` now drives the config sheet directly — no timing race possible
- Also adds missing `.presentationDetents([.medium, .large])` to the config sheet

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)