### PR TITLE
fix(ci): add shared LiftOS scheme so CI can resolve -scheme LiftOS

### DIFF
--- a/AdaptOS.xcodeproj/xcshareddata/xcschemes/LiftOS.xcscheme
+++ b/AdaptOS.xcodeproj/xcshareddata/xcschemes/LiftOS.xcscheme
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "946C5CDE883C4BDA0466935E"
+               BuildableName = "AdaptOS.app"
+               BlueprintName = "AdaptOS"
+               ReferencedContainer = "container:AdaptOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "275EDDD32F91D067009CDA8F"
+               BuildableName = "AdaptOSTests.xctest"
+               BlueprintName = "AdaptOSTests"
+               ReferencedContainer = "container:AdaptOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "946C5CDE883C4BDA0466935E"
+            BuildableName = "AdaptOS.app"
+            BlueprintName = "AdaptOS"
+            ReferencedContainer = "container:AdaptOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "946C5CDE883C4BDA0466935E"
+            BuildableName = "AdaptOS.app"
+            BlueprintName = "AdaptOS"
+            ReferencedContainer = "container:AdaptOS.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary
- Adds `AdaptOS.xcodeproj/xcshareddata/xcschemes/LiftOS.xcscheme` — the shared scheme CI needs
- Root cause: the scheme existed only in `xcuserdata/` (machine-local, gitignored) so CI runners never had it
- Scheme targets the `AdaptOS` native target (`946C5CDE883C4BDA0466935E`) and includes `AdaptOSTests` as the testable

## Why this happens (teaching moment)
Xcode has two kinds of schemes: **user schemes** (in `xcuserdata/`, not committed) and **shared schemes** (in `xcshareddata/xcschemes/`, committed). CI can only see shared schemes. When you create a scheme in Xcode it defaults to user-only — you have to explicitly tick "Shared" in the scheme manager to make it available to CI.

## Test plan
- [ ] CI passes on this PR (Build + Unit tests jobs both green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)