### PR TITLE
Fix CI workflow: use specific iOS version instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             -project AdaptOS.xcodeproj \
             -scheme LiftOS \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=17.2' \
             -skipPackagePluginValidation \
             clean build \
             CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions || \
@@ -55,7 +55,7 @@ jobs:
             -project AdaptOS.xcodeproj \
             -scheme LiftOS \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=17.2' \
             -skipPackagePluginValidation \
             clean build \
             CODE_SIGNING_ALLOWED=NO
@@ -79,14 +79,14 @@ jobs:
           xcodebuild \
             -project AdaptOS.xcodeproj \
             -scheme LiftOS \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=17.2' \
             -skipPackagePluginValidation \
             test \
             CODE_SIGNING_ALLOWED=NO | xcbeautify --renderer github-actions || \
           xcodebuild \
             -project AdaptOS.xcodeproj \
             -scheme LiftOS \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=17.2' \
             -skipPackagePluginValidation \
             test \
             CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary
- Pins all four `-destination` flags in ci.yml from `OS=latest` to `OS=17.2`
- Prevents CI failures caused by runner images shipping a newer iOS runtime that doesn't match the `iPhone 16` simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)