### PR TITLE
chore(repo): add PRODUCT.md, DESIGN.md, and issue-creation tooling

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -4,6 +4,7 @@
   { "name": "type:enhancement", "color": "a2eeef", "description": "Improvement to something that already exists" },
   { "name": "type:tech-debt",   "color": "fbca04", "description": "Code quality / refactor with no user-visible change" },
   { "name": "type:chore",       "color": "c5def5", "description": "Tooling, dependencies, CI, docs" },
+  { "name": "type:fix",         "color": "e4e669", "description": "Targeted code fix — behavior correction that isn't a full bug report" },
 
   { "name": "priority:P0-now",     "color": "b60205", "description": "Drop everything. Prod broken or data at risk" },
   { "name": "priority:P1-soon",    "color": "d93f0b", "description": "Important, next up" },
@@ -17,6 +18,7 @@
   { "name": "area:rest-timer",      "color": "1d76db", "description": "Rest timer logic, notifications, Live Activity" },
   { "name": "area:data-model",      "color": "1d76db", "description": "SwiftData schema, migrations, persistence" },
   { "name": "area:ui-polish",       "color": "1d76db", "description": "Haptics, animations, theme, micro-interactions" },
+  { "name": "area:accessibility",   "color": "1d76db", "description": "VoiceOver, Dynamic Type, Reduce Motion, tap targets, WCAG compliance" },
   { "name": "area:onboarding",      "color": "1d76db", "description": "First-launch flow, empty states, Sign in with Apple" },
   { "name": "area:profile",         "color": "1d76db", "description": "Profile tab, settings, user preferences" },
   { "name": "area:ai-assistant",    "color": "1d76db", "description": "Claude-powered plan generation, substitutions" },

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,285 @@
+---
+name: LiftOS
+description: A premium native iOS workout tracker for serious progressive-overload lifters
+colors:
+  accent: "Color.accentColor"
+  success: "Color.green"
+  warning: "Color.orange"
+  warmup: "Color.orange"
+  deload: "Color.orange"
+  highlight: "Color.yellow"
+  card-background: "Color(.secondarySystemBackground)"
+  elevated-background: "Color(.tertiarySystemBackground)"
+  text-primary: ".primary"
+  text-secondary: ".secondary"
+  text-tertiary: ".tertiary"
+typography:
+  large-title:
+    fontFamily: "SF Pro Display (system)"
+    fontSize: ".largeTitle"
+    fontWeight: "regular"
+  title2:
+    fontFamily: "SF Pro Display (system)"
+    fontSize: ".title2"
+    fontWeight: "medium"
+  title3:
+    fontFamily: "SF Pro Display (system)"
+    fontSize: ".title3"
+    fontWeight: "regular"
+  headline:
+    fontFamily: "SF Pro Text (system)"
+    fontSize: ".headline"
+    fontWeight: "semibold"
+  body:
+    fontFamily: "SF Pro Text (system)"
+    fontSize: ".body"
+    fontWeight: "regular"
+  body-medium:
+    fontFamily: "SF Pro Text (system)"
+    fontSize: ".body"
+    fontWeight: "medium"
+  subheadline:
+    fontFamily: "SF Pro Text (system)"
+    fontSize: ".subheadline"
+    fontWeight: "regular"
+  caption:
+    fontFamily: "SF Pro Text (system)"
+    fontSize: ".caption"
+    fontWeight: "regular"
+  caption-semibold:
+    fontFamily: "SF Pro Text (system)"
+    fontSize: ".caption"
+    fontWeight: "semibold"
+  numeric-display:
+    fontFamily: "SF Mono (system, design: .monospaced)"
+    fontSize: "48"
+    fontWeight: "bold"
+  numeric-readout:
+    fontFamily: "SF Mono (system, design: .monospaced)"
+    fontSize: ".title2"
+    fontWeight: "medium"
+rounded:
+  input: "6"
+  small: "8"
+  card: "12"
+  sheet: "20"
+spacing:
+  list-item: "4"
+  compact: "8"
+  card: "16"
+  section: "20"
+components:
+  card:
+    backgroundColor: "{colors.card-background}"
+    rounded: "{rounded.card}"
+    padding: "16"
+  button-primary:
+    backgroundColor: "{colors.accent}"
+    textColor: "white"
+    rounded: "{rounded.card}"
+    padding: "16"
+  set-row-checkmark-incomplete:
+    textColor: "{colors.text-secondary}"
+  set-row-checkmark-complete:
+    textColor: "{colors.success}"
+  numeric-input:
+    backgroundColor: "{colors.card-background}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.input}"
+    padding: "8"
+  rir-chip-unselected:
+    backgroundColor: "{colors.card-background}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.input}"
+  rir-chip-selected:
+    backgroundColor: "{colors.accent}"
+    textColor: "white"
+    rounded: "{rounded.input}"
+  sheet:
+    backgroundColor: "{colors.elevated-background}"
+    rounded: "{rounded.sheet}"
+---
+
+# Design System: LiftOS
+
+## 1. Overview
+
+**Creative North Star: "The Pro Athlete's Tool"**
+
+LiftOS dresses like a first-party iOS app and behaves like a clinical-grade fitness instrument. It speaks Apple's visual vocabulary — system semantic colors, SF Pro Text/Display, SF Symbols, system-native lists and sheets, system blue as the single accent — and pushes past Apple's own defaults exactly where a stock app would settle. Monospaced digits anywhere a number lives. Editorial weight contrast in row-level data. Spring-and-easeOut motion at the moments that matter, never as decoration. The result reads like Halide for cameras or Things 3 for tasks: clearly built on Apple's stack, just visibly more deliberate than what Apple ships in the same category.
+
+The system is **flat by default, expressive on cue.** Surfaces use tonal layering (`secondarySystemBackground` over `systemBackground`, `tertiarySystemBackground` for elevated overlays) instead of decorative shadows. The only literal `.shadow` lives on the rest-timer progress ring, where the colored glow is functional — it tells the user the timer is alive. Everywhere else, depth is implied by background tone, never by drop shadow.
+
+LiftOS explicitly **rejects** the over-stylized brutalist fitness aesthetic (Whoop-style neon-on-black, sci-fi HUD, all-caps masculine "beast mode" tone), the generic SaaS-dashboard cliché (hero-metric cards with big number / tiny label / decorative gradient, purple-to-blue gradients, glassmorphism as default, gradient text), and the spreadsheet-tracker failure mode (gray-on-gray rows, no hierarchy, accounting-software flat). The strategic line from PRODUCT.md carries through every decision below.
+
+**Key Characteristics:**
+- First-party iOS feel, elevated through deliberate craft (not invented from scratch)
+- System semantic colors only; system blue as the single accent
+- Tabular monospaced digits for every weight, rep count, time, and RPE/RIR readout
+- Tonal layering for depth; literal shadows are rare and functional
+- Spring-and-easeOut motion that enhances feedback, never gates input
+- Quiet rewards — no confetti, no streak banners, no celebratory modals
+- Density is composed and editorial, not flat or crowded
+- HIG compliance is the floor, not the ceiling
+
+## 2. Colors
+
+The palette is Apple's, used with discipline. There is one true accent (system blue), one success color (system green) reserved for set-completion and finish moments, and one alert color (system orange) shared across warmup sets, deload weeks, and rest-timer urgency. Yellow exists for PRs and top-set highlights and appears on screen at most a few times per session. Everything else is system semantic backgrounds and `.primary` / `.secondary` / `.tertiary` text styles, which adapt automatically to Dark Mode and Increase Contrast.
+
+### Primary
+- **System Blue** (`Color.accentColor`): the single brand accent. Worn by the Start Workout button, RIR chip selection, link affordances, the rest-timer progress ring at rest, the active-week badge on Home, and the muted "PREV" column highlight when the user beats last session. Used sparingly — never as a wash, never as a gradient, never on more than ~10% of any given screen at once.
+
+### Secondary
+- **System Green** (`Color.green`): set-completion checkmark color, Finish Workout success haptic affordance, rest-timer completion pulse, brief row-flash tint (`Color.green.opacity(0.08)`) on a completed set. The reward color. Never used decoratively; always tied to a logged moment.
+
+### Tertiary
+- **System Orange** (`Color.orange`): warmup set indicator (set number renders as "W" in orange when toggled), deload-week badge on plan rows, rest-timer last-five-seconds urgency (numeric digits scale up, ring stroke shifts to orange), and inline warmup tags in the workout summary. One color, three cousin roles.
+- **System Yellow** (`Color.yellow`): PR markers, top-set / trophy moments on the Workout Summary screen. The most restrained color — it should be rare enough that it earns the eye when it shows up.
+
+### Neutral
+- **Primary Background** (system, implicit via `Color(.systemBackground)`): root page backdrop. Adapts to Dark Mode automatically.
+- **Secondary System Background** (`Color(.secondarySystemBackground)`): card surfaces, set-row inputs, exercise card backgrounds, RIR chips at rest, the auto-rest-timer toggle bar. The default "card" surface for the whole app.
+- **Tertiary System Background** (`Color(.tertiarySystemBackground)`): elevated surfaces — modal sheets at full presentation, overlay panels, the rest-timer overlay's interior fill. Use only when a surface explicitly sits on top of a Secondary card.
+- **Primary Text** (`.primary`): all main copy, set numbers, weight/rep values when entered.
+- **Secondary Text** (`.secondary`): row labels (Set, Reps, Weight column headers), inactive states, supplementary metadata, last-session "prev" annotations.
+- **Tertiary Text** (`.tertiary`): unit labels (lbs, kg), placeholder digits in unfilled inputs, decorative metadata that should fade into the page.
+
+### Named Rules
+
+**The One Accent Rule.** System blue carries the brand. It is never paired with a second hue as a "secondary brand" — every other color in the palette has a literal functional role (success, warning, warmup, PR). If a visual element needs color and isn't tied to one of those roles, it stays neutral. No purple, no teal, no cyan. The accent is rare and it stays rare.
+
+**The Semantic-Only Rule.** Never use a literal hex value for text or background. Every color is a system semantic (`Color.accentColor`, `.primary`, `Color(.secondarySystemBackground)`) or a single tinted role exposed through `LiftTheme` (`success`, `warning`, `warmup`, `deload`, `highlight`). This is what makes the app adapt to Dark Mode, Increase Contrast, and tinted accent overrides without code changes. Hardcoded colors are forbidden.
+
+**The Reward-Color Rule.** Green and yellow only appear in response to a user's logged action — completing a set, hitting a PR, finishing a workout. They are *never* decorative. If you find yourself reaching for green on a static label, it is wrong. Switch to neutral.
+
+## 3. Typography
+
+**Display Font:** SF Pro Display (system, used implicitly at `.largeTitle`, `.title`, `.title2`, `.title3` via Dynamic Type)
+**Body Font:** SF Pro Text (system, used implicitly at `.headline`, `.body`, `.subheadline`, `.callout`, `.caption`, `.caption2` via Dynamic Type)
+**Numeric Font:** SF Mono / system monospaced (`design: .monospaced`) for every digit that represents weight, reps, time, RPE, RIR, set count, or volume
+
+**Character.** The pairing is Apple's — but used with editorial discipline. Type sizes always come from the semantic Dynamic Type scale (`.headline`, `.body`, `.caption`); fixed point sizes appear only for the rest-timer numeric display (48pt monospaced bold, the one true exception). Hierarchy is built through weight contrast (regular → medium → semibold → bold), not through size alone. Numbers wear monospaced everywhere they live so columns of weights and reps align cleanly without the eye doing arithmetic on glyph widths.
+
+### Hierarchy
+
+- **Large Title** (regular, `.largeTitle`, system line-height): screen titles in the navigation bar (`Today`, `Plans`, `History`, `Profile`).
+- **Title 2** (medium, `.title2`, often `design: .monospaced`): the active-workout running clock, prominent numeric readouts. Monospaced when it carries a number; default when it carries a label.
+- **Title 3** (regular, `.title3`): primary stat figures on the Workout Summary, large interactive icons.
+- **Headline** (semibold, `.headline`): exercise name on the active set row, section headers, sheet titles, navigation row labels. The single most-used hierarchy step.
+- **Body** (regular, `.body`): default running copy, descriptive lines.
+- **Body Medium** (medium, `.body`): emphasized inline values — entered weight/reps in a set row before completion, the active week label.
+- **Subheadline** (regular, `.subheadline`): secondary descriptive lines under a Headline (e.g. "3 exercises · 12 sets" under a routine name).
+- **Caption** (regular, `.caption`): row metadata, "lbs" / "kg" units inline next to numbers, last-session "prev" annotations.
+- **Caption Semibold** (semibold, `.caption`): column headers above set tables ("SET", "REPS", "WEIGHT", "RIR"), small inline labels that need to read as labels rather than data.
+- **Numeric Display** (bold, 48pt, `design: .monospaced`): the rest-timer countdown — the one place the system uses a fixed point size. Scales 1.05x in the last five seconds.
+- **Numeric Readout** (medium, `.title2`, `design: .monospaced`): the active-workout running clock and similar prominent timers.
+
+### Named Rules
+
+**The Monospaced-Digits Rule.** Every numeric value in the app — weight, reps, RIR, RPE, set number, total volume, time elapsed, time remaining — uses `design: .monospaced` or `.monospacedDigit()`. Tabular alignment is non-negotiable. A column of "135 / 140 / 145" must read as a vertical stack, not a ragged line of glyphs. This is the single highest-leverage typographic decision in the app.
+
+**The Semantic-Scale Rule.** Type sizes come from the Dynamic Type scale (`.headline`, `.body`, etc.), never hardcoded points. The rest-timer 48pt display is the *only* documented exception (large enough to read at arm's length under bright gym light). If a new view "needs" a hardcoded size, the answer is almost always to combine an existing scale step with a weight change.
+
+**The Weight-Contrast Rule.** Hierarchy between adjacent text elements uses ≥1 weight step difference (regular vs. medium, medium vs. semibold). Same-weight stacks read as flat — that's the spreadsheet failure mode.
+
+## 4. Elevation
+
+LiftOS is **flat by default** and uses **tonal layering** (Apple's `systemBackground` → `secondarySystemBackground` → `tertiarySystemBackground` ramp) for depth instead of literal shadows. A card on the Home screen sits on the page because its background is one tonal step lighter (in light mode) or darker (in dark mode) than the page beneath it — there is no `.shadow` on it.
+
+Material backgrounds (`.ultraThinMaterial`) are used sparingly: the auto-rest-timer toggle bar at the bottom of the active workout uses `.ultraThinMaterial` so it reads as floating chrome over scrolling content. This is the lone application of frosted material in the app and it's functional, not decorative.
+
+Literal shadows appear in exactly one documented place: the rest-timer progress ring carries a colored glow shadow (`.shadow(color: accent.opacity(0.4), radius: 6)`) so the timer feels alive at a glance from across the gym. The shadow color shifts to orange in the last five seconds. If a future feature wants to use `.shadow`, it needs an equally specific functional reason.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** No `.shadow` on cards, rows, sheets, buttons, or any surface at rest. Depth is conveyed by the tonal ramp (`systemBackground` → `secondarySystemBackground` → `tertiarySystemBackground`). If a card "looks flat against the background," the answer is the next tonal step, not a drop shadow.
+
+**The Functional-Glow Rule.** The only legitimate uses of `.shadow` are (a) the rest-timer progress ring at rest and during urgency, and (b) any future moment where the shadow is doing real work (e.g. a Live Activity element that needs to lift off the lock screen). Decorative ambient shadows under cards are forbidden.
+
+**The Sheet-Material-Rule.** Modal sheets use the system's default surface — they sit on `tertiarySystemBackground` with `presentationCornerRadius(20)` and `presentationDragIndicator(.visible)`. No custom shadow under the sheet, no glassmorphic blur except `.ultraThinMaterial` on the auto-rest toggle bar, no decorative outline.
+
+## 5. Components
+
+### Buttons
+- **Shape:** rounded rectangle, 12pt corner radius (`LiftTheme.cornerRadius`).
+- **Primary:** filled with `Color.accentColor`, white text, `.headline` weight, vertical padding ~16pt. Used for the Start Workout / Quick Workout / Finish Workout call-to-action and the rest-timer "Skip" button.
+- **Secondary / Ghost:** plain text in `Color.accentColor` at `.body` weight, no fill — for "Add Set", "Add Exercise", and similar inline affordances inside cards. They sit *inside* a card surface and don't compete with it.
+- **Tertiary / Destructive:** the swipe-to-delete row uses a system red filled background with a white trash icon, exposed only on swipe. Confirmation dialogs (`.confirmationDialog`) handle every destructive action — never a silent tap.
+- **Hover / Pressed:** system default press feedback. Don't override.
+
+### Cards / Containers
+- **Corner Style:** 12pt (`LiftTheme.cornerRadius`).
+- **Background:** `Color(.secondarySystemBackground)`. Always.
+- **Border:** none.
+- **Shadow:** none (per Flat-By-Default Rule).
+- **Internal Padding:** 16pt (`LiftTheme.cardSpacing`).
+- **Use:** the standard surface for routine rows on Home, exercise cards in the active workout, plan rows in the Plans tab, summary stat blocks. Cards never nest inside other cards.
+
+### Set Row (the signature component)
+The most-tapped, most-looked-at element in the app. One row contains: set number (or "W" for warmup, in orange), weight input, reps input, prev-session annotation in `.tertiary` text, completion checkmark, and an expanding RIR/RPE selector that slides in below on tap.
+
+- **Layout:** horizontal `HStack` with column alignment that matches the column headers ("SET", "REPS", "WEIGHT", "RIR") above. Tabular monospaced digits.
+- **Numeric inputs:** 6pt corner radius (`LiftTheme.inputCornerRadius`), `secondarySystemBackground` fill, `.body.weight(.medium)` text, `design: .monospaced`. Tap targets remain ≥44pt.
+- **Set number tap toggles warmup:** number → "W", color → `.orange`, with `.sensoryFeedback(.selection)`.
+- **Completion checkmark:** SF Symbol `checkmark.circle.fill` at `.title3`, `.secondary` when incomplete, `.green` when complete. On tap: bounce (scale 0.5 → 1.0 via spring), color fade-in, brief row tint flash (`Color.green.opacity(0.08)`, 0.6s decay), `.sensoryFeedback(.success)`.
+- **RIR selector:** appears below the row on completion via `.transition(.move(edge: .bottom).combined(with: .opacity))`. Six chips (0–5) using `inputCornerRadius` (6pt) — selected chip fills with `Color.accentColor`, unselected sits on `secondarySystemBackground`.
+
+### Inputs / Numeric Fields
+- **Style:** `secondarySystemBackground` fill, 6pt corner radius (`inputCornerRadius`), `.body.weight(.medium)` monospaced.
+- **Focus:** system default keyboard focus styling. No custom glow.
+- **Auto-fill:** entering a weight in Set 1 auto-fills the same weight in remaining sets — that interaction is part of the speed-of-logging principle.
+- **Error / Disabled:** disabled inputs read at `.tertiary` text color; error states are vanishingly rare in this app and use system orange + a `.confirmationDialog` rather than inline error chrome.
+
+### Sheets
+- **Corner Style:** 20pt (`presentationCornerRadius(20)`) on every sheet.
+- **Drag Indicator:** `presentationDragIndicator(.visible)` on every sheet.
+- **Detents:** purposeful per sheet — `NewRoutineSheet` and `NewExerciseSheet` use `.medium`; `EditPlanSheet` uses `.medium, .large`; `ExercisePickerView` uses `.large`; `WorkoutSummaryView` uses `.large` (and is dismiss-disabled).
+- **Background:** system default. No custom material, no custom shadow.
+
+### Rest Timer Overlay (signature component)
+A full-screen overlay that fades in over the active workout when a set completes (if auto-rest is enabled). Centered: a circular progress ring (system blue at rest, orange in the last five seconds) and the 48pt monospaced bold countdown. Below the ring: ±15s buttons on `systemGray3`, a Skip button on `accentColor`. The ring carries a colored glow shadow — the lone documented `.shadow` in the app.
+
+- **Entrance:** fade + scale (0.95 → 1.0) over 0.25s easeOut. No pop.
+- **Urgency state:** at ≤5 seconds, the digit text scales 1.0 → 1.05, ring stroke transitions to `Color.orange` over 0.3s easeInOut, glow color follows.
+- **Completion:** ring flashes green, brief 0.5s pause, then auto-dismiss with fade.
+- **Haptics:** `.impact(.light)` on ±15s, `.notification(.warning)` at zero.
+
+### Tab Bar
+- **Style:** system default `TabView` with SF Symbol icons (`figure.run`, `list.bullet.clipboard`, `clock.arrow.circlepath`, `person.crop.circle`).
+- **Active state:** system default tinting (system blue under default accent).
+- **Don't:** customize the tab bar background or shape. The system handles this correctly across iOS versions and Liquid Glass; overriding it breaks more than it improves.
+
+### Lists
+- **Style:** prefer `List` (`.insetGrouped` style) and `Form` for any data-entry / settings flow. Lean on system list semantics — swipe actions, context menus, drag-to-reorder, section headers — instead of hand-rolling row layouts.
+- **Custom rows** appear inside `List` rows when the data shape demands it (the active-workout exercise cards, for instance), but the *container* stays a system list whenever possible.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** use system semantic colors only: `Color.accentColor`, `.primary` / `.secondary` / `.tertiary`, `Color(.secondarySystemBackground)`, `Color(.tertiarySystemBackground)`, and the named roles in `LiftTheme` (`success`, `warning`, `warmup`, `deload`, `highlight`). The app must adapt to Dark Mode and Increase Contrast without code changes.
+- **Do** apply `design: .monospaced` (or `.monospacedDigit()`) to every numeric value: weight, reps, RPE, RIR, set number, time elapsed, time remaining, total volume.
+- **Do** drive hierarchy through font weight contrast (regular → medium → semibold → bold), not size alone.
+- **Do** use the four-step `LiftTheme` corner radii deliberately: 6 for inline numeric inputs, 8 for small chips, 12 for cards and primary buttons, 20 for modal sheets.
+- **Do** put `.sensoryFeedback` on every confirmation moment: set completion, RPE selection, warmup toggle, finish workout, rest timer ±15s, rest timer at zero.
+- **Do** use `.transition(.move(edge: .bottom).combined(with: .opacity))` for inline reveals like the RIR selector — they read as content arriving, not as a panel popping open.
+- **Do** use `easeOut(duration: 0.2–0.4)` for state changes and `spring(response: 0.5, dampingFraction: 0.6)` for the small handful of "rewarding" moments (trophy bounce, set-completion checkmark).
+- **Do** present every modal with `.presentationDragIndicator(.visible)` and `.presentationCornerRadius(20)`.
+- **Do** respect Reduce Motion: every spring/bounce/scale-in animation must check `@Environment(\.accessibilityReduceMotion)` and degrade to a simple opacity fade or no animation.
+- **Do** keep tap targets ≥44pt in the active-workout flow. No exceptions.
+
+### Don't:
+- **Don't** use hardcoded hex colors anywhere. If a color isn't a system semantic or a `LiftTheme` role, it doesn't belong in the app. (Per the Semantic-Only Rule.)
+- **Don't** use `.shadow` on cards, rows, sheets, or buttons at rest. Depth comes from the tonal ramp, not drop shadows. (Per the Flat-By-Default Rule.)
+- **Don't** introduce a second brand color alongside system blue. The accent stays rare and stays alone. (Per the One-Accent Rule.)
+- **Don't** use green or yellow decoratively. They appear only in response to a logged user action — set complete, workout finished, PR hit. (Per the Reward-Color Rule.)
+- **Don't** use `background-clip: text` equivalents (no gradient text via `.foregroundStyle(LinearGradient(...))`). One solid color, period.
+- **Don't** wrap a colored stripe down the side of a card or row (any `border-leading` greater than 1pt as a colored accent). Use full borders, background tints, or leading icons instead.
+- **Don't** build hero-metric cards: big number / tiny label / decorative gradient. That's the SaaS-dashboard cliché PRODUCT.md explicitly rejects.
+- **Don't** build identical-looking icon-heading-text card grids. Each card type should look like itself.
+- **Don't** use glassmorphism / `.ultraThinMaterial` decoratively. The one allowed use is the auto-rest toggle bar where it functions as floating chrome over scrolling content.
+- **Don't** congratulate the user on a light set. No coach voice, no streak guilt, no "you haven't trained in 3 days" notifications. (Per PRODUCT.md's Trust the User's Expertise principle.)
+- **Don't** hardcode font point sizes. The rest-timer 48pt monospaced display is the only documented exception. Everything else uses Dynamic Type scale (`.headline`, `.body`, etc.).
+- **Don't** use all-caps for body text or button labels. SF Pro is not a display font that wants caps. The only acceptable caps are short metadata labels (column headers like "SET" / "REPS") at `.caption.weight(.semibold)`.
+- **Don't** use emojis or trophy-style iconography in product copy. SF Symbols only, used semantically.
+- **Don't** present a fullscreen confetti / celebratory animation on PR or workout completion. The Workout Summary screen carries the moment; no extra ceremony layered on top. (Per the Quiet Rewards principle.)
+- **Don't** stack animations during rapid set logging. If a user taps five checkmarks in two seconds, animations must not queue, lag, or block input. Speed of logging is sacred.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,58 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Serious progressive-overload lifters. People who follow structured multi-week training plans, care about double progression (beating last session's reps before adding weight), and understand concepts like RPE, deload weeks, and rep ranges without needing them explained. They're disciplined, often training 4–6 days per week, and have used apps like Hevy, RP Hypertrophy, or MacroFactor Workouts before — and have opinions about what those apps got wrong.
+
+**Use context:** in a gym, mid-workout, between sets. Phone in one hand, sometimes sweaty. The app is opened many times per session and must be glanceable, fast to log into, and forgiving of a quick tap. Sessions last 45–90 minutes with the screen returning to focus dozens of times.
+
+**Job to be done:** log every set, rep, and weight against a planned routine; see what was done last session inline; know exactly what to beat today; review progress over weeks without ceremony.
+
+## Product Purpose
+
+LiftOS is a native iOS workout tracker built around the **double-progression** model: previous session's reps/weight are shown inline next to the input fields so the user always knows the target to beat. Plans organize multi-week training (with deload weeks) → daily routines → exercises → prescribed sets. The template side (plan) and the logging side (session) are intentionally separate so plan edits never corrupt historical records. Data is local-only via SwiftData (no backend, no account required beyond Sign in with Apple).
+
+**Success looks like:** a serious lifter installs LiftOS, imports or builds a plan in 10 minutes, and finds it genuinely faster and more pleasant to log a workout than whatever they were using before — without losing any data fidelity, and without the social/gamified noise of Hevy or the spreadsheet feel of Strong.
+
+## Brand Personality
+
+**Three words:** premium, native, expert.
+
+**Voice and tone:** quiet competence. Speaks to the user as a peer who already knows the vocabulary (RPE, deload, rep range, double progression). No congratulatory copy on light sets. No emojis in product copy. No fitness-bro language ("crush it," "beast mode," "GAINS"). When the app does speak — empty states, completion summary, an unprompted observation — the line is short, plain, and useful.
+
+**Emotional goals:** the user opens it and feels *this is how Apple would build a workout tracker if they cared more*. Not stock. Not novelty. Refined first-party feel — the kind of polish that signals craft without announcing itself. Logging a set should feel mechanical and satisfying; finishing a workout should feel earned, not celebrated at you.
+
+## Anti-references
+
+**Over-stylized / brutalist fitness apps** (Whoop-style dark-mode-only with neon accents, sci-fi HUD vibe, all-caps everywhere, aggressive masculine "beast mode" tone). LiftOS is for people who take training seriously enough that they don't need the app to perform seriousness on their behalf.
+
+**Generic SaaS dashboards.** No hero-metric cards (big number / tiny label / decorative gradient). No purple-to-blue brand gradients. No identical icon-heading-text card grids. No glassmorphism used decoratively. No gradient text. No side-stripe colored borders on cards.
+
+**Spreadsheet-aesthetic trackers** (Strong, FitNotes). Dense gray-on-gray rows with no hierarchy, no breathing room, no sense that anyone made deliberate visual choices — that's the failure mode to avoid. LiftOS *is* dense by necessity (prev session, target reps, RPE, weight all visible at once) but the density should feel composed and editorial, not accounting-software flat.
+
+## Design Principles
+
+1. **First-party feel, elevated craft.** HIG compliance is the floor, not the ceiling. Use system semantic styles (`.headline`, `.body`, `.primary`, system blue accent), system-native components (`List`, `Form`, `GroupBox`), and Apple's own gestures (swipe actions, context menus, confirmation dialogs). Then push past the defaults with deliberate typography weight pairings, monospaced digits for all numbers, considered spacing rhythm, and subtle motion that Apple's stock apps don't bother with. The bar is *Things 3 / Halide* level of polish, expressed through Apple's vocabulary — not invented from scratch.
+
+2. **Speed of logging is sacred.** The set-completion checkmark is tapped 50+ times per session, often quickly, sometimes one-handed. Every interaction in the active-workout flow is judged by *how fast can a focused lifter log a set?* — not by how interesting the animation is. Animations must enhance feedback (haptics, color flash, micro-bounce), never block input or stack up under rapid taps. If a polish layer adds even 100ms of perceived friction during logging, it's wrong.
+
+3. **Trust the user's expertise.** No tooltips explaining RPE. No coach-voice congratulating a 95 lb warm-up set. No nudges, no streak guilt, no "you haven't trained in 3 days!" notifications. The user is competent and self-motivated; the app's job is to record accurately, surface previous-session data clearly, and stay out of the way. Empty states are calm, not anxious.
+
+4. **Quiet rewards beat loud ones.** Hitting a PR is noted with a small inline accent (a subtle badge, a number that gains weight, a single haptic), not celebrated with confetti or a fullscreen modal. The genuine reward is the data: previous session beaten, target range hit, weight progressed. Visible progress is the prize — the app doesn't perform congratulation on top of it.
+
+5. **Density should feel composed, not crowded.** Lifters need to see prev-session reps/weight, target rep range, current input fields, and RPE simultaneously — that's a lot in one row. The answer is editorial typographic hierarchy (weight, color, leading), not extra cards or expanding panels. Information density is a feature; visual noise is the bug. Think a well-typeset table, not a stat dashboard.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA minimum across the app. All four firm requirements:
+
+- **Dynamic Type at every size, xSmall through AX5.** Layouts in `ActiveWorkoutView`, `SetLogRow`, history lists, and plan-builder sheets must hold up at the largest accessibility sizes. No clipped text, no broken horizontal stacks — switch to vertical layouts at AX1+ where needed.
+- **VoiceOver complete.** Every set/rep/weight/RPE is readable in logical order. Every icon-only button has an accessibility label. Custom accessibility actions on set rows (complete, mark warmup, delete) so blind users can log without fighting the row layout.
+- **Reduce Motion respected.** All Phase 6 polish — checkmark bounce, RPE slide-in, rest-timer entrance, breathing pulse on Start Workout, summary stats stagger — gracefully degrades to a simple opacity fade or no animation when Reduce Motion is enabled.
+- **Bold Text + Increase Contrast.** All UI text thickens correctly. Custom Theme colors meet 4.5:1 against their backgrounds in normal mode and continue to pass under Increase Contrast.
+
+Sweaty hands and gym lighting are an inclusion concern even outside formal a11y: 44pt minimum tap targets are firm (no exceptions in the active workout flow), and the rest timer remains legible from arm's length under bright fluorescent gym light.

--- a/docs/file-audit-issues-remainder.sh
+++ b/docs/file-audit-issues-remainder.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# File issues 3-5 from the /impeccable audit.
+# Uses temp files for issue bodies to avoid heredoc quoting issues.
+set -euo pipefail
+REPO="garrettcurtis92/LiftOS-2.0"
+TMPDIR_CUSTOM=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR_CUSTOM"; }
+trap cleanup EXIT
+
+# ── Issue 3 ──────────────────────────────────────────────────────────────────
+echo "==> Filing Issue 3 — Dynamic Type AX1+ layout (P1)..."
+cat > "$TMPDIR_CUSTOM/issue3.md" << 'BODY'
+## Problem
+
+The set row uses fixed-width frames (lines 537, 553, 572, 591) and matching column-header widths (lines 443-451). At Dynamic Type AX1+ the input text clips; at AX3+ the row overflows on iPhone SE. `PRODUCT.md` commits to Dynamic Type at all sizes (xSmall through AX5) with explicit guidance to "switch to vertical layouts at AX1+ where needed" — currently no `dynamicTypeSize` check exists.
+
+## Acceptance Criteria
+
+- [ ] Read `@Environment(\.dynamicTypeSize)` in `SetLogRow`.
+- [ ] At default sizes (.xxxLarge and below), keep the existing compact tabular HStack layout — it is correct there.
+- [ ] At `.accessibility1` and above, switch to a vertical VStack layout that wraps the inputs cleanly.
+- [ ] Column-header row (`setHeader`) hidden or restructured at AX1+ so it does not compete with the new vertical row layout.
+- [ ] Simulator test: Dynamic Type slider at xSmall, Large (default), xxxLarge, AX1, AX3, AX5 — no clipped text, no horizontal overflow on iPhone SE width.
+- [ ] VoiceOver pass at AX5 confirming row reading order remains logical.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `PRODUCT.md` Accessibility & Inclusion: "Layouts in `ActiveWorkoutView`, `SetLogRow`, history lists, and plan-builder sheets must hold up at the largest accessibility sizes."
+BODY
+
+ISSUE3=$(gh issue create \
+  --repo "$REPO" \
+  --title "fix(workout): adapt ActiveWorkoutView set row for Dynamic Type AX1+" \
+  --label "type:fix,priority:P1-soon,area:workout-logging,area:accessibility" \
+  --body-file "$TMPDIR_CUSTOM/issue3.md")
+echo "  Created: $ISSUE3"
+
+# ── Issue 4 ──────────────────────────────────────────────────────────────────
+echo ""
+echo "==> Filing Issue 4 — LiftTheme token routing (P2)..."
+cat > "$TMPDIR_CUSTOM/issue4.md" << 'BODY'
+## Problem
+
+`LiftTheme` exists (`LiftOS/Utilities/Theme.swift`) and is partially adopted across the app, but `ActiveWorkoutView.swift` reaches around it for several raw values. The visual result is identical today; the risk is that future re-skinning, accent overrides, or token tuning will skip these direct usages.
+
+## Acceptance Criteria
+
+- [ ] `Color.green` (lines 587, 596) replaced with `LiftTheme.success`.
+- [ ] `Color.orange` for warmup context (line 536) replaced with `LiftTheme.warmup`.
+- [ ] `Color.accentColor` (lines 399, 634) replaced with `LiftTheme.accent`.
+- [ ] `Color.secondarySystemBackground` (lines 555, 574, 634) replaced with `LiftTheme.cardBackground`.
+- [ ] `RoundedRectangle(cornerRadius: 6)` (lines 523, 556, 575, 636) replaced with `RoundedRectangle(cornerRadius: LiftTheme.inputCornerRadius)`.
+- [ ] Padding literals: `4` to `LiftTheme.listItemSpacing`, `8` to `LiftTheme.compactSpacing`, `16` to `LiftTheme.cardSpacing` where the literal matches the token. Leave genuinely off-grid values alone.
+- [ ] Visual regression: side-by-side simulator comparison shows zero pixel difference vs. `main`.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `LiftOS/Utilities/Theme.swift`.
+- `DESIGN.md` Section 2 Colors (Semantic-Only Rule).
+BODY
+
+ISSUE4=$(gh issue create \
+  --repo "$REPO" \
+  --title "chore(workout): route ActiveWorkoutView through LiftTheme tokens" \
+  --label "type:chore,priority:P2-later,area:workout-logging,area:ui-polish" \
+  --body-file "$TMPDIR_CUSTOM/issue4.md")
+echo "  Created: $ISSUE4"
+
+# ── Issue 5 ──────────────────────────────────────────────────────────────────
+echo ""
+echo "==> Filing Issue 5 — DESIGN.md ultraThinMaterial reconciliation (P2)..."
+cat > "$TMPDIR_CUSTOM/issue5.md" << 'BODY'
+## Problem
+
+`DESIGN.md` Section 4 Elevation ("The Sheet-Material Rule") describes `.ultraThinMaterial` as "the lone application of frosted material in the app," referring to the auto-rest toggle bar. In practice, `ActiveWorkoutView`s `workoutHeader` (line 197) also uses `.ultraThinMaterial` as floating chrome over scrolling content — same functional justification, but a second instance not acknowledged in the spec.
+
+A decision is required before this issue is started.
+
+## Acceptance Criteria
+
+Pick **(a)** or **(b)**:
+
+- [ ] **(a)** Update `DESIGN.md` Section 4 Elevation to list both documented uses of `.ultraThinMaterial` (workout header chrome AND auto-rest toggle bar) as the spec exceptions, with a brief rule defining what qualifies as "functional chrome over scrolling content."
+- [ ] **(b)** Remove `.ultraThinMaterial` from the workout header (revert to `Color(.systemBackground)` or no background, letting the system nav bar handle chrome) so the spec's "lone application" claim stays accurate.
+
+Decision lives with Garrett before work begins.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `DESIGN.md` Section 4 Elevation.
+BODY
+
+ISSUE5=$(gh issue create \
+  --repo "$REPO" \
+  --title "docs(design): reconcile DESIGN.md ultraThinMaterial usage with code" \
+  --label "type:chore,priority:P2-later,area:ui-polish,discussion" \
+  --body-file "$TMPDIR_CUSTOM/issue5.md")
+echo "  Created: $ISSUE5"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================================"
+echo "Issues 3-5 filed:"
+echo "  Issue 3 (P1 — Dynamic Type):  $ISSUE3"
+echo "  Issue 4 (P2 — LiftTheme):     $ISSUE4"
+echo "  Issue 5 (P2 — DESIGN.md):     $ISSUE5"
+echo ""
+echo "Full set:"
+echo "  Issue 1 (P0 — a11y):   https://github.com/garrettcurtis92/LiftOS-2.0/issues/12"
+echo "  Issue 2 (P0 — perf):   https://github.com/garrettcurtis92/LiftOS-2.0/issues/13"
+echo "  Issue 3 (P1):          $ISSUE3"
+echo "  Issue 4 (P2):          $ISSUE4"
+echo "  Issue 5 (P2):          $ISSUE5"
+echo "============================================================"

--- a/docs/file-audit-issues.sh
+++ b/docs/file-audit-issues.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# ============================================================
+# File 5 GitHub issues from the /impeccable audit of
+# LiftOS/Views/Workout/ActiveWorkoutView.swift
+#
+# Run from the repo root:
+#   chmod +x docs/file-audit-issues.sh
+#   ./docs/file-audit-issues.sh
+#
+# Prereqs: gh authenticated  (`gh auth status`)
+#          repo:             garrettcurtis92/LiftOS-2.0
+# ============================================================
+
+set -euo pipefail
+REPO="garrettcurtis92/LiftOS-2.0"
+
+echo "==> Syncing new labels to GitHub..."
+for label in \
+  'type:fix|e4e669|Targeted code fix — behavior correction that isn'"'"'t a full bug report' \
+  'area:accessibility|1d76db|VoiceOver, Dynamic Type, Reduce Motion, tap targets, WCAG compliance'
+do
+  IFS='|' read -r name color desc <<< "$label"
+  if gh label list --repo "$REPO" --limit 200 | grep -q "^${name}"; then
+    gh label edit "$name" --repo "$REPO" --color "$color" --description "$desc"
+    echo "  updated: $name"
+  else
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$desc"
+    echo "  created: $name"
+  fi
+done
+
+echo ""
+echo "==> Filing Issue 1 — a11y hardening (P0)..."
+ISSUE1=$(gh issue create \
+  --repo "$REPO" \
+  --title "fix(workout): a11y hardening for ActiveWorkoutView" \
+  --label "type:fix,priority:P0-now,area:workout-logging,area:accessibility" \
+  --body "$(cat <<'EOF'
+## Problem
+
+The `/impeccable` audit of `LiftOS/Views/Workout/ActiveWorkoutView.swift` found multiple accessibility blockers, including one P0 that prevents VoiceOver users from completing the basic workout-logging flow. `PRODUCT.md` commits to **WCAG 2.1 AA minimum across the app** with VoiceOver-complete and 44pt-minimum tap targets as firm requirements; the file currently violates both.
+
+## Acceptance Criteria
+
+- [ ] Manual swipe-to-delete (`DragGesture`, lines 597–617) replaced with system `.swipeActions(edge: .trailing)` so VoiceOver rotor exposes the delete action automatically.
+- [ ] Set-completion button (lines 582–593) has `.accessibilityLabel("Set N")`, `.accessibilityValue` reflecting completion state, `.accessibilityHint` describing the toggle.
+- [ ] Weight + Reps `TextField`s (lines 549–579) have `.accessibilityLabel` referencing the unit from `UserProfile.weightUnit`.
+- [ ] Set-number warmup-toggle (lines 531–540) has `.accessibilityLabel` / `.accessibilityValue` / `.accessibilityHint` describing the warmup toggle.
+- [ ] Auto-rest timer toggle (lines 184–193) has `.accessibilityLabel("Auto rest timer")` and `.accessibilityValue("On"/"Off")`.
+- [ ] Ellipsis Menu trigger (lines 427–432) has `.accessibilityLabel("Exercise options")`.
+- [ ] Decorative column-header checkmark glyph (lines 450–452) marked `.accessibilityHidden(true)`.
+- [ ] RIR close button (lines 642–649) has `.accessibilityLabel("Close RIR selector")`.
+- [ ] Set row exposes `.accessibilityActions` with rotor entries: Mark complete / Toggle warmup / Delete set.
+- [ ] Tap targets ≥44pt on set-number toggle, completion checkmark, and RIR chips (visible glyphs unchanged).
+- [ ] Every animation in the file gates on `@Environment(\.accessibilityReduceMotion)` and degrades to `.easeOut(0.15)` or no animation. Covers checkmark spring, row flash, RIR transition, expand/collapse, delete-set, swipe-offset (if retained).
+- [ ] Manual VoiceOver pass on a physical device: every set row is fully operable without sighted help.
+- [ ] Manual Reduce Motion pass: enable Settings → Accessibility → Motion → Reduce Motion, verify no spring/scale animations play.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift` (run on this branch).
+- `PRODUCT.md` § Accessibility & Inclusion (firm requirements: Dynamic Type, VoiceOver, Reduce Motion, Bold Text + Increase Contrast).
+- `DESIGN.md` § 6 Do's and Don'ts (Reduce Motion respected; 44pt tap targets in active workout flow).
+
+EOF
+)")
+echo "  Created: $ISSUE1"
+
+echo ""
+echo "==> Filing Issue 2 — previousSets fetch storm (P0)..."
+ISSUE2=$(gh issue create \
+  --repo "$REPO" \
+  --title "perf(workout): eliminate previousSets fetch storm in ActiveWorkoutView" \
+  --label "type:fix,priority:P0-now,area:workout-logging" \
+  --body "$(cat <<'EOF'
+## Problem
+
+`previousSets(for:)` (line 249) runs a `FetchDescriptor<SessionExercise>` query for every exercise on screen, on every body re-render of `ActiveWorkoutView`. The parent re-renders once per second because `elapsedSeconds` is `@State` updated on a 1 Hz `Timer`. Net result: ~N SwiftData fetches per second during an active workout. On a database with months of history this becomes visible jank, directly violating `PRODUCT.md`'s **"Speed of logging is sacred"** principle.
+
+The animation-chain code in `toggleCompletion` (lines 693, 701) also uses `DispatchQueue.main.asyncAfter`, which won't cancel cleanly on rapid re-toggle and can stack during fast logging.
+
+## Acceptance Criteria
+
+- [ ] Elapsed-time display extracted into a child `TimerLabel` view that owns its own `@State` for the tick, so the timer no longer invalidates `ActiveWorkoutView.body`.
+- [ ] `previousSets` results cached in parent `@State` keyed by exercise ID; populated `.task` on appear and invalidated when the exercise list changes (add / remove / swap / reorder). No fetch in the body render path.
+- [ ] `DispatchQueue.main.asyncAfter` chains in `toggleCompletion` replaced with `.task(id:)` or equivalent structured-concurrency pattern that cancels cleanly on view churn or rapid re-toggle.
+- [ ] Manual test: rapid-tap five set checkmarks in two seconds, verify no animation queue lag and no visible frame drops.
+- [ ] Manual test: open Instruments → Time Profiler during an active workout with ≥10 historical sessions, confirm `FetchDescriptor` is not in the hot path of the timer-driven re-render.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `PRODUCT.md` § Design Principles #2 (Speed of logging is sacred).
+
+EOF
+)")
+echo "  Created: $ISSUE2"
+
+echo ""
+echo "==> Filing Issue 3 — Dynamic Type AX1+ layout (P1)..."
+ISSUE3=$(gh issue create \
+  --repo "$REPO" \
+  --title "fix(workout): adapt ActiveWorkoutView set row for Dynamic Type AX1+" \
+  --label "type:fix,priority:P1-soon,area:workout-logging,area:accessibility" \
+  --body "$(cat <<'EOF'
+## Problem
+
+The set row uses fixed-width frames (lines 537, 553, 572, 591) and matching column-header widths (lines 443–451). At Dynamic Type AX1+ the input text clips; at AX3+ the row overflows on iPhone SE. `PRODUCT.md` commits to Dynamic Type at all sizes (xSmall through AX5) with explicit guidance to "switch to vertical layouts at AX1+ where needed" — currently no `dynamicTypeSize` check exists.
+
+## Acceptance Criteria
+
+- [ ] Read `@Environment(\.dynamicTypeSize)` in `SetLogRow`.
+- [ ] At default sizes (≤ `.xxxLarge`), keep the existing compact tabular `HStack` layout (it's correct there).
+- [ ] At `.accessibility1` and above, switch to a vertical (`VStack`-of-rows) layout that wraps the inputs cleanly.
+- [ ] Column-header row (`setHeader`) hidden or restructured at AX1+ so it doesn't compete with the new vertical row layout.
+- [ ] Simulator test: Dynamic Type slider at xSmall, Large (default), xxxLarge, AX1, AX3, AX5 — no clipped text, no horizontal overflow on iPhone SE width.
+- [ ] VoiceOver pass at AX5 confirming row reading order remains logical.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `PRODUCT.md` § Accessibility & Inclusion ("Layouts in `ActiveWorkoutView`, `SetLogRow`, history lists, and plan-builder sheets must hold up at the largest accessibility sizes").
+
+EOF
+)")
+echo "  Created: $ISSUE3"
+
+echo ""
+echo "==> Filing Issue 4 — LiftTheme token routing (P2)..."
+ISSUE4=$(gh issue create \
+  --repo "$REPO" \
+  --title "chore(workout): route ActiveWorkoutView through LiftTheme tokens" \
+  --label "type:chore,priority:P2-later,area:workout-logging,area:ui-polish" \
+  --body "$(cat <<'EOF'
+## Problem
+
+`LiftTheme` exists (`LiftOS/Utilities/Theme.swift`) and is partially adopted across the app, but `ActiveWorkoutView.swift` reaches around it for several values. The visual result is identical today; the risk is that future re-skinning, accent overrides, or token tuning will skip these direct usages.
+
+## Acceptance Criteria
+
+- [ ] `Color.green` (lines 587, 596) → `LiftTheme.success`.
+- [ ] `Color.orange` for warmup context (line 536) → `LiftTheme.warmup`.
+- [ ] `Color.accentColor` (lines 399, 634) → `LiftTheme.accent`.
+- [ ] `Color.secondarySystemBackground` (lines 555, 574, 634) → `LiftTheme.cardBackground`.
+- [ ] `RoundedRectangle(cornerRadius: 6)` (lines 523, 556, 575, 636) → `RoundedRectangle(cornerRadius: LiftTheme.inputCornerRadius)`.
+- [ ] Padding literals: `4` → `LiftTheme.listItemSpacing`, `8` → `LiftTheme.compactSpacing`, `16` → `LiftTheme.cardSpacing` where literal matches token. Leave genuinely off-grid values alone.
+- [ ] Visual regression: side-by-side simulator comparison shows zero pixel difference vs. `main`.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `LiftOS/Utilities/Theme.swift`.
+- `DESIGN.md` § 2 Colors (Semantic-Only Rule).
+
+EOF
+)")
+echo "  Created: $ISSUE4"
+
+echo ""
+echo "==> Filing Issue 5 — DESIGN.md ultraThinMaterial reconciliation (P2)..."
+ISSUE5=$(gh issue create \
+  --repo "$REPO" \
+  --title "docs(design): reconcile DESIGN.md ultraThinMaterial usage with code" \
+  --label "type:chore,priority:P2-later,area:ui-polish,discussion" \
+  --body "$(cat <<'EOF'
+## Problem
+
+`DESIGN.md` § 4 Elevation ("The Sheet-Material Rule") describes `.ultraThinMaterial` as "the lone application of frosted material in the app," referring to the auto-rest toggle bar. In practice, `ActiveWorkoutView`'s `workoutHeader` (line 197) also uses `.ultraThinMaterial` as floating chrome over scrolling content — same functional justification, but a second instance not acknowledged in the spec.
+
+**A decision is required before this issue is started.**
+
+## Acceptance Criteria
+
+Pick **(a)** or **(b)**:
+
+- [ ] **(a)** Update `DESIGN.md` § 4 Elevation to list both documented uses of `.ultraThinMaterial` (workout header chrome AND auto-rest toggle bar) as the spec'd exceptions, with a brief test defining what qualifies as "functional chrome over scrolling content."
+- [ ] **(b)** Remove `.ultraThinMaterial` from the workout header (revert to `Color(.systemBackground)` or no background, letting the system nav bar handle chrome) so the spec's "lone application" claim stays accurate.
+
+Decision lives with Garrett before work begins.
+
+## References
+
+- `/impeccable` audit report on `ActiveWorkoutView.swift`.
+- `DESIGN.md` § 4 Elevation.
+
+EOF
+)")
+echo "  Created: $ISSUE5"
+
+echo ""
+echo "============================================================"
+echo "All 5 issues filed:"
+echo "  Issue 1 (P0 — a11y):          $ISSUE1"
+echo "  Issue 2 (P0 — perf):          $ISSUE2"
+echo "  Issue 3 (P1 — Dynamic Type):  $ISSUE3"
+echo "  Issue 4 (P2 — LiftTheme):     $ISSUE4"
+echo "  Issue 5 (P2 — DESIGN.md):     $ISSUE5"
+echo ""
+echo "Next step: add all 5 to the LiftOS Roadmap project board."
+echo "  gh project view 3 --owner garrettcurtis92 --web"
+echo "============================================================"


### PR DESCRIPTION
## Summary

Sets up the strategic and visual specification that future UI work and skill-driven flows (`impeccable`, `ui-ux-pro-max`, `superpowers`) read from. No code changes; pure repo setup.

- **`PRODUCT.md`** — register (`product`), users, brand personality, anti-references, five design principles, and firm accessibility commitments. Generated via the `/impeccable teach` interview.
- **`DESIGN.md`** — full visual system (colors, typography, elevation, components, do's and don'ts) with YAML frontmatter tokens and named rules. Generated via `/impeccable document` scan of the existing `Theme.swift` and view files; adapted from the Stitch web format to SwiftUI vocabulary.
- **`.github/labels.json`** — adds `type:fix` and `area:accessibility`, both required by the audit-driven issues #12-#16.
- **`docs/file-audit-issues*.sh`** — one-shot `gh` CLI scripts that filed the five audit issues. Kept as a reference for future audit-driven workflows; can be removed later if the pattern doesn't repeat.

## Why now

The `/impeccable audit` of `ActiveWorkoutView.swift` (which generated issues #12-#16) needed the strategic + visual spec loaded for grading. PRODUCT.md and DESIGN.md will continue to be referenced as each issue is worked. Landing them on `main` first means every subsequent `fix/` and `chore/` branch starts from a clean spec'd baseline.

## Test plan

- [x] PRODUCT.md and DESIGN.md render correctly in GitHub's Markdown preview
- [x] `node .claude/skills/impeccable/scripts/load-context.mjs` (run from repo root after merge) reports `hasProduct: true` and `hasDesign: true`
- [x] New labels appear under https://github.com/garrettcurtis92/LiftOS-2.0/labels
- [x] Issues #12-#16 still render their labels correctly after merge

## Notes

- No app source modified.
- No `CLAUDE.md` change in this PR (a previous Design-context appendix was reverted intentionally; PRODUCT.md / DESIGN.md are the canonical source instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)