### PR TITLE
fix(workout): a11y hardening for ActiveWorkoutView

### DIFF
--- a/AdaptOS.xcodeproj/project.pbxproj
+++ b/AdaptOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4951174867C6D588F97E7C65 /* ActiveWorkoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D2BCB508327C146D9967F6 /* ActiveWorkoutView.swift */; };
 		4B82653AD198540618664197 /* SessionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDBC2CB356ECD7937FAD5451 /* SessionBuilder.swift */; };
 		4C0E41A637D3B829CB54CCE3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013C9BD58C161C857268477B /* ContentView.swift */; };
+		59E088C78848F9CC95044217 /* Animation+LiftOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58523C64999E32F3528544C8 /* Animation+LiftOS.swift */; };
 		5C6FC847278AEBF164DD76B6 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC108F080FF10450D81AC3A /* View+Extensions.swift */; };
 		5CCFD411B64E501A8609C0F1 /* ModelContainer+LiftOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3FA73719F0D26DB955850C /* ModelContainer+LiftOS.swift */; };
 		62DBE72CFF6480CD87A257CD /* NewPlanSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791F33AA71FFEEDDA765EC87 /* NewPlanSheet.swift */; };
@@ -77,6 +78,7 @@
 		4BBC8CB1DC163170E7711348 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		523D2D58097E498739F4ED7B /* SessionExercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExercise.swift; sourceTree = "<group>"; };
 		5318049FF0E3C2383A6208C9 /* ProgressionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressionEngine.swift; sourceTree = "<group>"; };
+		58523C64999E32F3528544C8 /* Animation+LiftOS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Animation+LiftOS.swift"; sourceTree = "<group>"; };
 		5C10D0DEA4EFFF0C859AB558 /* HomeTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTab.swift; sourceTree = "<group>"; };
 		791F33AA71FFEEDDA765EC87 /* NewPlanSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewPlanSheet.swift; sourceTree = "<group>"; };
 		7C3FA73719F0D26DB955850C /* ModelContainer+LiftOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelContainer+LiftOS.swift"; sourceTree = "<group>"; };
@@ -112,6 +114,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		275EDDD52F91D067009CDA8F /* LiftOSTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = LiftOSTests;
 			sourceTree = "<group>";
 		};
@@ -260,6 +264,7 @@
 				7C3FA73719F0D26DB955850C /* ModelContainer+LiftOS.swift */,
 				D2CFECD4E813033A9073B51B /* Theme.swift */,
 				ABC108F080FF10450D81AC3A /* View+Extensions.swift */,
+				58523C64999E32F3528544C8 /* Animation+LiftOS.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -320,8 +325,6 @@
 				275EDDD52F91D067009CDA8F /* LiftOSTests */,
 			);
 			name = AdaptOSTests;
-			packageProductDependencies = (
-			);
 			productName = LiftOSTests;
 			productReference = 275EDDD42F91D067009CDA8F /* AdaptOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -338,8 +341,6 @@
 			dependencies = (
 			);
 			name = AdaptOS;
-			packageProductDependencies = (
-			);
 			productName = LiftOS;
 			productReference = F7B53C0D1CEC06EB190031A9 /* AdaptOS.app */;
 			productType = "com.apple.product-type.application";
@@ -451,6 +452,7 @@
 				ACC209C8E82FA5771ECDD77F /* WorkoutPlan.swift in Sources */,
 				68A35911F7E89D353B97B8E7 /* WorkoutSession.swift in Sources */,
 				8431073F7200BD12D01B0826 /* WorkoutSummaryView.swift in Sources */,
+				59E088C78848F9CC95044217 /* Animation+LiftOS.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -492,7 +494,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdaptOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AdaptOS";
 			};
 			name = Debug;
@@ -519,7 +521,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdaptOS.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AdaptOS";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -550,7 +552,7 @@
 				PRODUCT_NAME = AdaptOS;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -635,7 +637,7 @@
 				PRODUCT_NAME = AdaptOS;
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};

--- a/LiftOS/Utilities/Animation+LiftOS.swift
+++ b/LiftOS/Utilities/Animation+LiftOS.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+extension Animation {
+    static func liftBounce(reduceMotion: Bool) -> Animation {
+        reduceMotion
+            ? .easeOut(duration: 0.12)
+            : .spring(response: 0.3, dampingFraction: 0.5)
+    }
+
+    static func liftSpring(reduceMotion: Bool) -> Animation {
+        reduceMotion
+            ? .easeOut(duration: 0.15)
+            : .spring(response: 0.5, dampingFraction: 0.6)
+    }
+
+    static func liftEaseOut(duration: Double, reduceMotion: Bool) -> Animation {
+        .easeOut(duration: reduceMotion ? min(duration, 0.12) : duration)
+    }
+
+    static func liftEaseInOut(duration: Double, reduceMotion: Bool) -> Animation {
+        reduceMotion
+            ? .easeOut(duration: min(duration, 0.12))
+            : .easeInOut(duration: duration)
+    }
+}

--- a/LiftOS/Views/Workout/ActiveWorkoutView.swift
+++ b/LiftOS/Views/Workout/ActiveWorkoutView.swift
@@ -238,7 +238,7 @@ struct ActiveWorkoutView: View {
     // MARK: - Actions
 
     private func toggleExpanded(_ exercise: SessionExercise) {
-        withAnimation(.liftEaseInOut(duration: 0.2, reduceMotion: reduceMotion)) {
+        withAnimation(Animation.liftEaseInOut(duration: 0.2, reduceMotion: reduceMotion)) {
             expandedExerciseID = expandedExerciseID == exercise.id ? nil : exercise.id
         }
     }
@@ -468,7 +468,7 @@ struct ExerciseLogCard: View {
     }
 
     private func deleteSet(_ sessionSet: SessionSet) {
-        withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) {
+        withAnimation(Animation.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) {
             sessionExercise.sets.removeAll { $0.id == sessionSet.id }
             modelContext.delete(sessionSet)
             for (index, set) in sessionExercise.sortedSets.enumerated() {
@@ -522,176 +522,16 @@ struct SetLogRow: View {
     var body: some View {
         VStack(spacing: 0) {
             ZStack(alignment: .trailing) {
-                // Delete button revealed on swipe
-                if onDelete != nil {
-                    Button {
-                        onDelete?()
-                    } label: {
-                        Image(systemName: "trash.fill")
-                            .font(.body.weight(.medium))
-                            .foregroundStyle(.white)
-                            .frame(width: 60, height: 36)
-                            .background(Color.red)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
-                    }
-                    .buttonStyle(.plain)
-                    .opacity(showDeleteButton ? 1 : 0)
-                }
-
-                HStack {
-                    Button {
-                        sessionSet.isWarmup.toggle()
-                    } label: {
-                        Text(sessionSet.isWarmup ? "W" : "\(sessionSet.setNumber)")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(sessionSet.isWarmup ? .orange : .primary)
-                            .frame(width: 36, alignment: .leading)
-                            .frame(minHeight: 44)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Set \(sessionSet.setNumber)")
-                    .accessibilityValue(sessionSet.isWarmup ? "Warmup" : "Working set")
-                    .accessibilityHint("Double-tap to toggle warmup")
-                    .sensoryFeedback(.selection, trigger: sessionSet.isWarmup)
-
-                    // Previous session
-                    Text(previousDisplay ?? "–")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-
-                    TextField("0", text: $weightText)
-                        .keyboardType(.decimalPad)
-                        .multilineTextAlignment(.center)
-                        .font(.body.weight(.medium))
-                        .frame(width: 72)
-                        .padding(.vertical, 6)
-                        .background(Color.secondarySystemBackground)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                        .focused($focusedField, equals: .weight)
-                        .accessibilityLabel("Weight")
-                        .onChange(of: weightText) { _, newValue in
-                            sessionSet.weight = Double(newValue) ?? 0
-                        }
-                        .onChange(of: focusedField) { oldFocus, newFocus in
-                            if oldFocus == .weight && newFocus != .weight && sessionSet.weight > 0 {
-                                autoFillWeight(sessionSet.weight)
-                            }
-                        }
-
-                    TextField("0", text: $repsText)
-                        .keyboardType(.numberPad)
-                        .multilineTextAlignment(.center)
-                        .font(.body.weight(.medium))
-                        .frame(width: 56)
-                        .padding(.vertical, 6)
-                        .background(Color.secondarySystemBackground)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                        .focused($focusedField, equals: .reps)
-                        .accessibilityLabel("Reps")
-                        .onChange(of: repsText) { _, newValue in
-                            sessionSet.reps = Int(newValue) ?? 0
-                        }
-
-                    Button {
-                        toggleCompletion()
-                    } label: {
-                        Image(systemName: sessionSet.isCompleted ? "checkmark.circle.fill" : "circle")
-                            .font(.title3)
-                            .foregroundStyle(sessionSet.isCompleted ? .green : .secondary)
-                            .scaleEffect(checkmarkScale)
-                            .frame(width: 44, height: 44)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.borderless)
-                    .accessibilityLabel("Set \(sessionSet.setNumber)")
-                    .accessibilityValue(sessionSet.isCompleted ? "Completed" : "Not completed")
-                    .accessibilityHint("Double-tap to toggle completion")
-                    .sensoryFeedback(.success, trigger: completionTrigger)
-                    .sensoryFeedback(.impact(flexibility: .soft), trigger: uncheckTrigger)
-                }
-                .offset(x: swipeOffset)
-                .background(rowFlash ? Color.green.opacity(0.08) : Color.clear)
-                .gesture(
-                    onDelete != nil ?
-                    DragGesture(minimumDistance: 20)
-                        .onChanged { value in
-                            if value.translation.width < 0 {
-                                swipeOffset = max(value.translation.width, -70)
-                            }
-                        }
-                        .onEnded { value in
-                            withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) {
-                                if value.translation.width < -40 {
-                                    swipeOffset = -70
-                                    showDeleteButton = true
-                                } else {
-                                    swipeOffset = 0
-                                    showDeleteButton = false
-                                }
-                            }
-                        }
-                    : nil
-                )
+                swipeDeleteButton
+                mainRow
             }
 
             if showRIR && sessionSet.isCompleted {
-                HStack(spacing: 6) {
-                    Text("RIR")
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                    ForEach(0...5, id: \.self) { value in
-                        Button {
-                            sessionSet.rir = value
-                            withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
-                        } label: {
-                            Text("\(value)")
-                                .font(.caption.weight(.medium))
-                                .frame(width: 32, height: 28)
-                                .background(sessionSet.rir == value ? Color.accentColor : Color.secondarySystemBackground)
-                                .foregroundStyle(sessionSet.rir == value ? .white : .primary)
-                                .clipShape(RoundedRectangle(cornerRadius: 6))
-                                .frame(minWidth: 44, minHeight: 44)
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("RIR \(value)")
-                        .accessibilityHint("Reps in reserve. Double-tap to record.")
-                    }
-                    .sensoryFeedback(.selection, trigger: sessionSet.rir)
-                    Spacer()
-                    Button {
-                        withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .frame(minWidth: 44, minHeight: 44)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Close RIR selector")
-                }
-                .padding(.top, 4)
-                .padding(.leading, 36)
-                .transition(.move(edge: .bottom).combined(with: .opacity))
+                rirSelector
             }
         }
         .padding(.vertical, 4)
-        .accessibilityActions {
-            Button(sessionSet.isCompleted ? "Mark not completed" : "Mark completed") {
-                toggleCompletion()
-            }
-            Button(sessionSet.isWarmup ? "Mark working set" : "Mark as warmup") {
-                sessionSet.isWarmup.toggle()
-            }
-            if let onDelete {
-                Button("Delete set", role: .destructive) {
-                    onDelete()
-                }
-            }
-        }
+        .accessibilityActions { rowAccessibilityActions }
         .onAppear {
             weightText = sessionSet.weight > 0 ? formatWeight(sessionSet.weight) : ""
             repsText = sessionSet.reps > 0 ? "\(sessionSet.reps)" : ""
@@ -699,6 +539,203 @@ struct SetLogRow: View {
         .onChange(of: sessionSet.weight) { _, newWeight in
             if focusedField != .weight {
                 weightText = newWeight > 0 ? formatWeight(newWeight) : ""
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var swipeDeleteButton: some View {
+        if onDelete != nil {
+            Button {
+                onDelete?()
+            } label: {
+                Image(systemName: "trash.fill")
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(.white)
+                    .frame(width: 60, height: 36)
+                    .background(Color.red)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+            }
+            .buttonStyle(.plain)
+            .opacity(showDeleteButton ? 1 : 0)
+        }
+    }
+
+    private var mainRow: some View {
+        HStack {
+            setNumberButton
+            previousLabel
+            weightField
+            repsField
+            completionButton
+        }
+        .offset(x: swipeOffset)
+        .background(rowFlash ? Color.green.opacity(0.08) : Color.clear)
+        .gesture(swipeGesture)
+    }
+
+    private var setNumberButton: some View {
+        Button {
+            sessionSet.isWarmup.toggle()
+        } label: {
+            Text(sessionSet.isWarmup ? "W" : "\(sessionSet.setNumber)")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(sessionSet.isWarmup ? .orange : .primary)
+                .frame(width: 36, alignment: .leading)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Set \(sessionSet.setNumber)")
+        .accessibilityValue(sessionSet.isWarmup ? "Warmup" : "Working set")
+        .accessibilityHint("Double-tap to toggle warmup")
+        .sensoryFeedback(.selection, trigger: sessionSet.isWarmup)
+    }
+
+    private var previousLabel: some View {
+        Text(previousDisplay ?? "–")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private var weightField: some View {
+        TextField("0", text: $weightText)
+            .keyboardType(.decimalPad)
+            .multilineTextAlignment(.center)
+            .font(.body.weight(.medium))
+            .frame(width: 72)
+            .padding(.vertical, 6)
+            .background(Color.secondarySystemBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .focused($focusedField, equals: .weight)
+            .accessibilityLabel("Weight")
+            .onChange(of: weightText) { _, newValue in
+                sessionSet.weight = Double(newValue) ?? 0
+            }
+            .onChange(of: focusedField) { oldFocus, newFocus in
+                if oldFocus == .weight && newFocus != .weight && sessionSet.weight > 0 {
+                    autoFillWeight(sessionSet.weight)
+                }
+            }
+    }
+
+    private var repsField: some View {
+        TextField("0", text: $repsText)
+            .keyboardType(.numberPad)
+            .multilineTextAlignment(.center)
+            .font(.body.weight(.medium))
+            .frame(width: 56)
+            .padding(.vertical, 6)
+            .background(Color.secondarySystemBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .focused($focusedField, equals: .reps)
+            .accessibilityLabel("Reps")
+            .onChange(of: repsText) { _, newValue in
+                sessionSet.reps = Int(newValue) ?? 0
+            }
+    }
+
+    private var completionButton: some View {
+        Button {
+            toggleCompletion()
+        } label: {
+            Image(systemName: sessionSet.isCompleted ? "checkmark.circle.fill" : "circle")
+                .font(.title3)
+                .foregroundStyle(sessionSet.isCompleted ? .green : .secondary)
+                .scaleEffect(checkmarkScale)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .accessibilityLabel("Set \(sessionSet.setNumber)")
+        .accessibilityValue(sessionSet.isCompleted ? "Completed" : "Not completed")
+        .accessibilityHint("Double-tap to toggle completion")
+        .sensoryFeedback(.success, trigger: completionTrigger)
+        .sensoryFeedback(.impact(flexibility: .soft), trigger: uncheckTrigger)
+    }
+
+    private var swipeGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onChanged { value in
+                guard onDelete != nil, value.translation.width < 0 else { return }
+                swipeOffset = max(value.translation.width, -70)
+            }
+            .onEnded { value in
+                guard onDelete != nil else { return }
+                withAnimation(Animation.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) {
+                    if value.translation.width < -40 {
+                        swipeOffset = -70
+                        showDeleteButton = true
+                    } else {
+                        swipeOffset = 0
+                        showDeleteButton = false
+                    }
+                }
+            }
+    }
+
+    private var rirSelector: some View {
+        HStack(spacing: 6) {
+            Text("RIR")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(0...5, id: \.self) { value in
+                rirChip(for: value)
+            }
+            .sensoryFeedback(.selection, trigger: sessionSet.rir)
+            Spacer()
+            rirCloseButton
+        }
+        .padding(.top, 4)
+        .padding(.leading, 36)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+
+    private func rirChip(for value: Int) -> some View {
+        Button {
+            sessionSet.rir = value
+            withAnimation(Animation.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
+        } label: {
+            Text("\(value)")
+                .font(.caption.weight(.medium))
+                .frame(width: 32, height: 28)
+                .background(sessionSet.rir == value ? Color.accentColor : Color.secondarySystemBackground)
+                .foregroundStyle(sessionSet.rir == value ? .white : .primary)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("RIR \(value)")
+        .accessibilityHint("Reps in reserve. Double-tap to record.")
+    }
+
+    private var rirCloseButton: some View {
+        Button {
+            withAnimation(Animation.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
+        } label: {
+            Image(systemName: "xmark")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Close RIR selector")
+    }
+
+    @ViewBuilder
+    private var rowAccessibilityActions: some View {
+        Button(sessionSet.isCompleted ? "Mark not completed" : "Mark completed") {
+            toggleCompletion()
+        }
+        Button(sessionSet.isWarmup ? "Mark working set" : "Mark as warmup") {
+            sessionSet.isWarmup.toggle()
+        }
+        if let onDelete {
+            Button("Delete set", role: .destructive) {
+                onDelete()
             }
         }
     }
@@ -715,28 +752,28 @@ struct SetLogRow: View {
         if sessionSet.isCompleted {
             sessionSet.completedAt = nil
             sessionSet.rir = nil
-            withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
+            withAnimation(Animation.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
             uncheckTrigger.toggle()
         } else {
             sessionSet.completedAt = Date()
             focusedField = nil
             completionTrigger.toggle()
 
-            withAnimation(.liftBounce(reduceMotion: reduceMotion)) {
+            withAnimation(Animation.liftBounce(reduceMotion: reduceMotion)) {
                 checkmarkScale = 0.5
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                withAnimation(.liftBounce(reduceMotion: reduceMotion)) {
+                withAnimation(Animation.liftBounce(reduceMotion: reduceMotion)) {
                     checkmarkScale = 1.0
                 }
             }
 
-            withAnimation(.liftEaseOut(duration: 0.1, reduceMotion: reduceMotion)) { rowFlash = true }
+            withAnimation(Animation.liftEaseOut(duration: 0.1, reduceMotion: reduceMotion)) { rowFlash = true }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                withAnimation(.liftEaseOut(duration: 0.3, reduceMotion: reduceMotion)) { rowFlash = false }
+                withAnimation(Animation.liftEaseOut(duration: 0.3, reduceMotion: reduceMotion)) { rowFlash = false }
             }
 
-            withAnimation(.liftEaseOut(duration: 0.25, reduceMotion: reduceMotion)) { showRIR = true }
+            withAnimation(Animation.liftEaseOut(duration: 0.25, reduceMotion: reduceMotion)) { showRIR = true }
             onCompleted()
         }
     }

--- a/LiftOS/Views/Workout/ActiveWorkoutView.swift
+++ b/LiftOS/Views/Workout/ActiveWorkoutView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct ActiveWorkoutView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var session: WorkoutSession
 
     @State private var elapsedSeconds: Int = 0
@@ -187,9 +188,14 @@ struct ActiveWorkoutView: View {
                 Image(systemName: autoRestTimer ? "timer" : "timer.slash")
                     .font(.body.weight(.medium))
                     .foregroundStyle(autoRestTimer ? Color.accentColor : .secondary)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .padding(.trailing, 16)
+            .accessibilityLabel("Auto rest timer")
+            .accessibilityValue(autoRestTimer ? "On" : "Off")
+            .accessibilityHint("Double-tap to toggle automatic rest timer between sets")
             .sensoryFeedback(.selection, trigger: autoRestTimer)
         }
         .frame(maxWidth: .infinity)
@@ -232,7 +238,7 @@ struct ActiveWorkoutView: View {
     // MARK: - Actions
 
     private func toggleExpanded(_ exercise: SessionExercise) {
-        withAnimation(.easeInOut(duration: 0.2)) {
+        withAnimation(.liftEaseInOut(duration: 0.2, reduceMotion: reduceMotion)) {
             expandedExerciseID = expandedExerciseID == exercise.id ? nil : exercise.id
         }
     }
@@ -347,6 +353,7 @@ struct ActiveWorkoutView: View {
 
 struct ExerciseLogCard: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var sessionExercise: SessionExercise
     let previousSets: [Int: String]
     let isExpanded: Bool
@@ -428,8 +435,11 @@ struct ExerciseLogCard: View {
                 Image(systemName: "ellipsis")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                    .padding(8)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
             }
+            .accessibilityLabel("Exercise options")
+            .accessibilityHint("Swap or remove this exercise")
 
             Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                 .font(.caption.weight(.semibold))
@@ -449,17 +459,18 @@ struct ExerciseLogCard: View {
                 .frame(width: 56, alignment: .center)
             Image(systemName: "checkmark")
                 .frame(width: 36)
+                .accessibilityHidden(true)
         }
         .font(.caption2.weight(.semibold))
         .foregroundStyle(.secondary)
         .padding(.bottom, 4)
+        .accessibilityHidden(true)
     }
 
     private func deleteSet(_ sessionSet: SessionSet) {
-        withAnimation(.easeOut(duration: 0.2)) {
+        withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) {
             sessionExercise.sets.removeAll { $0.id == sessionSet.id }
             modelContext.delete(sessionSet)
-            // Reindex set numbers
             for (index, set) in sessionExercise.sortedSets.enumerated() {
                 set.setNumber = index + 1
             }
@@ -487,6 +498,7 @@ struct ExerciseLogCard: View {
 // MARK: - Set Log Row
 
 struct SetLogRow: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var sessionSet: SessionSet
     let allSets: [SessionSet]
     let previousDisplay: String?
@@ -527,7 +539,6 @@ struct SetLogRow: View {
                 }
 
                 HStack {
-                    // Set number — tap to toggle warmup
                     Button {
                         sessionSet.isWarmup.toggle()
                     } label: {
@@ -535,8 +546,13 @@ struct SetLogRow: View {
                             .font(.subheadline.weight(.medium))
                             .foregroundStyle(sessionSet.isWarmup ? .orange : .primary)
                             .frame(width: 36, alignment: .leading)
+                            .frame(minHeight: 44)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Set \(sessionSet.setNumber)")
+                    .accessibilityValue(sessionSet.isWarmup ? "Warmup" : "Working set")
+                    .accessibilityHint("Double-tap to toggle warmup")
                     .sensoryFeedback(.selection, trigger: sessionSet.isWarmup)
 
                     // Previous session
@@ -545,7 +561,6 @@ struct SetLogRow: View {
                         .foregroundStyle(.tertiary)
                         .frame(maxWidth: .infinity, alignment: .center)
 
-                    // Weight input
                     TextField("0", text: $weightText)
                         .keyboardType(.decimalPad)
                         .multilineTextAlignment(.center)
@@ -555,6 +570,7 @@ struct SetLogRow: View {
                         .background(Color.secondarySystemBackground)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                         .focused($focusedField, equals: .weight)
+                        .accessibilityLabel("Weight")
                         .onChange(of: weightText) { _, newValue in
                             sessionSet.weight = Double(newValue) ?? 0
                         }
@@ -564,7 +580,6 @@ struct SetLogRow: View {
                             }
                         }
 
-                    // Reps input
                     TextField("0", text: $repsText)
                         .keyboardType(.numberPad)
                         .multilineTextAlignment(.center)
@@ -574,11 +589,11 @@ struct SetLogRow: View {
                         .background(Color.secondarySystemBackground)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                         .focused($focusedField, equals: .reps)
+                        .accessibilityLabel("Reps")
                         .onChange(of: repsText) { _, newValue in
                             sessionSet.reps = Int(newValue) ?? 0
                         }
 
-                    // Complete toggle
                     Button {
                         toggleCompletion()
                     } label: {
@@ -586,9 +601,13 @@ struct SetLogRow: View {
                             .font(.title3)
                             .foregroundStyle(sessionSet.isCompleted ? .green : .secondary)
                             .scaleEffect(checkmarkScale)
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.borderless)
-                    .frame(width: 36)
+                    .accessibilityLabel("Set \(sessionSet.setNumber)")
+                    .accessibilityValue(sessionSet.isCompleted ? "Completed" : "Not completed")
+                    .accessibilityHint("Double-tap to toggle completion")
                     .sensoryFeedback(.success, trigger: completionTrigger)
                     .sensoryFeedback(.impact(flexibility: .soft), trigger: uncheckTrigger)
                 }
@@ -603,7 +622,7 @@ struct SetLogRow: View {
                             }
                         }
                         .onEnded { value in
-                            withAnimation(.easeOut(duration: 0.2)) {
+                            withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) {
                                 if value.translation.width < -40 {
                                     swipeOffset = -70
                                     showDeleteButton = true
@@ -617,7 +636,6 @@ struct SetLogRow: View {
                 )
             }
 
-            // RIR selector — shown after set is completed
             if showRIR && sessionSet.isCompleted {
                 HStack(spacing: 6) {
                     Text("RIR")
@@ -626,7 +644,7 @@ struct SetLogRow: View {
                     ForEach(0...5, id: \.self) { value in
                         Button {
                             sessionSet.rir = value
-                            withAnimation(.easeOut(duration: 0.2)) { showRIR = false }
+                            withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
                         } label: {
                             Text("\(value)")
                                 .font(.caption.weight(.medium))
@@ -634,19 +652,26 @@ struct SetLogRow: View {
                                 .background(sessionSet.rir == value ? Color.accentColor : Color.secondarySystemBackground)
                                 .foregroundStyle(sessionSet.rir == value ? .white : .primary)
                                 .clipShape(RoundedRectangle(cornerRadius: 6))
+                                .frame(minWidth: 44, minHeight: 44)
+                                .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("RIR \(value)")
+                        .accessibilityHint("Reps in reserve. Double-tap to record.")
                     }
                     .sensoryFeedback(.selection, trigger: sessionSet.rir)
                     Spacer()
                     Button {
-                        withAnimation(.easeOut(duration: 0.2)) { showRIR = false }
+                        withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
                     } label: {
                         Image(systemName: "xmark")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Close RIR selector")
                 }
                 .padding(.top, 4)
                 .padding(.leading, 36)
@@ -654,6 +679,19 @@ struct SetLogRow: View {
             }
         }
         .padding(.vertical, 4)
+        .accessibilityActions {
+            Button(sessionSet.isCompleted ? "Mark not completed" : "Mark completed") {
+                toggleCompletion()
+            }
+            Button(sessionSet.isWarmup ? "Mark working set" : "Mark as warmup") {
+                sessionSet.isWarmup.toggle()
+            }
+            if let onDelete {
+                Button("Delete set", role: .destructive) {
+                    onDelete()
+                }
+            }
+        }
         .onAppear {
             weightText = sessionSet.weight > 0 ? formatWeight(sessionSet.weight) : ""
             repsText = sessionSet.reps > 0 ? "\(sessionSet.reps)" : ""
@@ -675,34 +713,30 @@ struct SetLogRow: View {
 
     private func toggleCompletion() {
         if sessionSet.isCompleted {
-            // Un-check
             sessionSet.completedAt = nil
             sessionSet.rir = nil
-            withAnimation(.easeOut(duration: 0.2)) { showRIR = false }
+            withAnimation(.liftEaseOut(duration: 0.2, reduceMotion: reduceMotion)) { showRIR = false }
             uncheckTrigger.toggle()
         } else {
-            // Complete — bounce + flash + haptic
             sessionSet.completedAt = Date()
             focusedField = nil
             completionTrigger.toggle()
 
-            // Checkmark scale bounce
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+            withAnimation(.liftBounce(reduceMotion: reduceMotion)) {
                 checkmarkScale = 0.5
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                withAnimation(.liftBounce(reduceMotion: reduceMotion)) {
                     checkmarkScale = 1.0
                 }
             }
 
-            // Row flash
-            withAnimation(.easeIn(duration: 0.1)) { rowFlash = true }
+            withAnimation(.liftEaseOut(duration: 0.1, reduceMotion: reduceMotion)) { rowFlash = true }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                withAnimation(.easeOut(duration: 0.3)) { rowFlash = false }
+                withAnimation(.liftEaseOut(duration: 0.3, reduceMotion: reduceMotion)) { rowFlash = false }
             }
 
-            withAnimation(.easeOut(duration: 0.25)) { showRIR = true }
+            withAnimation(.liftEaseOut(duration: 0.25, reduceMotion: reduceMotion)) { showRIR = true }
             onCompleted()
         }
     }


### PR DESCRIPTION
## Summary

Addresses the bulk of the audit-flagged Accessibility (2/4) dimension on `ActiveWorkoutView.swift`. Brings the file in line with PRODUCT.md's firm a11y commitments: VoiceOver-complete, 44pt-minimum tap targets in the active-workout flow, Reduce Motion respected.

Closes #12.

## Changes

**New file:** `LiftOS/Utilities/Animation+LiftOS.swift`
- Helper extension exposing `liftBounce`, `liftSpring`, `liftEaseOut`, `liftEaseInOut`. Each takes a `reduceMotion: Bool` and degrades to a short `easeOut` when on. Reusable across the rest of the app for follow-up Reduce-Motion passes (`RestTimerView`, `WorkoutSummaryView`, `HomeTab`).

**Edits in `ActiveWorkoutView.swift`:**
- Auto-rest timer toggle: 44pt tap target + `accessibilityLabel` / `accessibilityValue` / `accessibilityHint`.
- Ellipsis exercise-options menu: 44pt tap target + label + hint.
- Decorative column-header `checkmark` glyph and the entire `setHeader` row marked `accessibilityHidden(true)`.
- Set-number warmup-toggle button: 44pt tap target + label/value/hint covering the warmup-toggle affordance.
- Weight + Reps `TextField`s: `accessibilityLabel("Weight")` / `accessibilityLabel("Reps")`.
- Completion checkmark: 44pt tap target + label/value/hint announcing set number and completion state.
- RIR chips: 44pt tap targets via outer frame; visible chip size unchanged. Each chip labeled "RIR N".
- RIR close button: 44pt tap target + label.
- Set row exposes `.accessibilityActions` with rotor entries: Mark complete / Toggle warmup / Delete set.
- Every `withAnimation` in the file routed through the new helpers — covers expand/collapse, deleteSet, swipe end, RIR show/hide, checkmark bounce, row flash.

## Pragmatic deviation from issue body

Issue #12's first acceptance criterion called for replacing the manual swipe-to-delete `DragGesture` with system `.swipeActions`. The architecture (set rows are nested inside `GroupBox` inside a List row, not direct List rows) doesn't support `.swipeActions` without restructuring `ExerciseLogCard`. The functional a11y goal — VoiceOver users can delete a set — is met via `.accessibilityActions` instead. Restructuring the card to enable native swipe semantics is worth its own follow-up issue if you want it.

## Out of scope (covered by later issues)

- `previousSets` fetch storm + `DispatchQueue.main.asyncAfter` chains → #13
- Dynamic Type AX1+ vertical layout → #14
- `LiftTheme` token consistency → #15

## Test plan

**Build verification (Xcode):**
- [ ] Project builds clean against iOS 17 simulator. SourceKit diagnostics seen during edit (e.g. "Cannot find 'WorkoutSession' in scope") were from out-of-target evaluation; the actual Xcode build should be clean. Worth confirming before merge.

**Physical device — VoiceOver:**
- [ ] Open the active workout. With VoiceOver on, navigate a set row element-by-element. Each control announces its purpose: "Set 1, Working set, Double-tap to toggle warmup", "Weight, 0", "Reps, 0", "Set 1, Not completed, Double-tap to toggle completion".
- [ ] On a set row, open the rotor → "Actions". Three custom actions appear: Mark complete / Toggle warmup / Delete set. Trigger each; behavior matches sighted-user equivalents.
- [ ] Auto-rest timer toggle in the header announces "Auto rest timer, On" / "Off" and the hint.
- [ ] Ellipsis menu announces "Exercise options".
- [ ] RIR selector chips announce "RIR 0" through "RIR 5"; close button announces "Close RIR selector".

**Physical device — Reduce Motion:**
- [ ] Settings → Accessibility → Motion → Reduce Motion ON.
- [ ] Tap a set checkmark: no spring bounce on the icon, no row-flash bounce. State changes still visible (color shift) but with a brief easeOut, not elastic.
- [ ] Expand/collapse an exercise card: no spring; quick easeOut.
- [ ] RIR slide-in transition: gentler, shorter. No move-from-bottom bounce.

**Physical device — tap targets:**
- [ ] Set-number toggle, completion checkmark, and RIR chips are reliably tappable with sweaty / large fingers; no missed taps. Visible glyph sizes look unchanged from before.
- [ ] Auto-rest toggle and ellipsis menu in the header have generous hit areas.

**Regression — sighted-user paths:**
- [ ] Tap to expand exercise → smooth.
- [ ] Tap a set checkmark → bounce, row flash, RIR slide-in, success haptic.
- [ ] Swipe a set row left → delete affordance reveals, tap to delete → row animates out.
- [ ] All other haptics / animations behave as before with Reduce Motion off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)