### PR TITLE
fix(workout): adapt ActiveWorkoutView set row for Dynamic Type AX1+

### DIFF
--- a/LiftOS/Views/Workout/ActiveWorkoutView.swift
+++ b/LiftOS/Views/Workout/ActiveWorkoutView.swift
@@ -337,6 +337,7 @@ struct ActiveWorkoutView: View {
 struct ExerciseLogCard: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Bindable var sessionExercise: SessionExercise
     let previousSets: [Int: String]
     let isExpanded: Bool
@@ -362,7 +363,9 @@ struct ExerciseLogCard: View {
                     Divider()
                         .padding(.vertical, 8)
 
-                    setHeader
+                    if !dynamicTypeSize.isAccessibilitySize {
+                        setHeader
+                    }
 
                     ForEach(sessionExercise.sortedSets) { sessionSet in
                         SetLogRow(
@@ -482,6 +485,7 @@ struct ExerciseLogCard: View {
 
 struct SetLogRow: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Bindable var sessionSet: SessionSet
     let allSets: [SessionSet]
     let previousDisplay: String?
@@ -507,7 +511,11 @@ struct SetLogRow: View {
         VStack(spacing: 0) {
             ZStack(alignment: .trailing) {
                 swipeDeleteButton
-                mainRow
+                if dynamicTypeSize.isAccessibilitySize {
+                    accessibilityRow
+                } else {
+                    mainRow
+                }
             }
 
             if showRIR && sessionSet.isCompleted {
@@ -564,13 +572,51 @@ struct SetLogRow: View {
         HStack {
             setNumberButton
             previousLabel
-            weightField
-            repsField
+            weightField.frame(width: 72)
+            repsField.frame(width: 56)
             completionButton
         }
         .offset(x: swipeOffset)
         .background(rowFlash ? Color.green.opacity(0.08) : Color.clear)
         .gesture(swipeGesture)
+    }
+
+    private var accessibilityRow: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                setNumberButton
+                Spacer()
+                completionButton
+            }
+
+            if previousDisplay != nil {
+                HStack(spacing: 6) {
+                    Text("Last:")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(previousDisplay ?? "")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            HStack(alignment: .bottom, spacing: 12) {
+                labeledField("Weight", field: weightField)
+                labeledField("Reps", field: repsField)
+            }
+        }
+        .offset(x: swipeOffset)
+        .background(rowFlash ? Color.green.opacity(0.08) : Color.clear)
+        .gesture(swipeGesture)
+    }
+
+    private func labeledField<Field: View>(_ label: String, field: Field) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            field.frame(maxWidth: .infinity)
+        }
     }
 
     private var setNumberButton: some View {
@@ -603,7 +649,6 @@ struct SetLogRow: View {
             .keyboardType(.decimalPad)
             .multilineTextAlignment(.center)
             .font(.body.weight(.medium))
-            .frame(width: 72)
             .padding(.vertical, 6)
             .background(Color.secondarySystemBackground)
             .clipShape(RoundedRectangle(cornerRadius: 6))
@@ -624,7 +669,6 @@ struct SetLogRow: View {
             .keyboardType(.numberPad)
             .multilineTextAlignment(.center)
             .font(.body.weight(.medium))
-            .frame(width: 56)
             .padding(.vertical, 6)
             .background(Color.secondarySystemBackground)
             .clipShape(RoundedRectangle(cornerRadius: 6))
@@ -674,7 +718,16 @@ struct SetLogRow: View {
             }
     }
 
+    @ViewBuilder
     private var rirSelector: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            accessibilityRIRSelector
+        } else {
+            compactRIRSelector
+        }
+    }
+
+    private var compactRIRSelector: some View {
         HStack(spacing: 6) {
             Text("RIR")
                 .font(.caption2.weight(.semibold))
@@ -688,6 +741,28 @@ struct SetLogRow: View {
         }
         .padding(.top, 4)
         .padding(.leading, 36)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+
+    private var accessibilityRIRSelector: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("RIR")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                rirCloseButton
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(0...5, id: \.self) { value in
+                        rirChip(for: value)
+                    }
+                }
+            }
+            .sensoryFeedback(.selection, trigger: sessionSet.rir)
+        }
+        .padding(.top, 4)
         .transition(.move(edge: .bottom).combined(with: .opacity))
     }
 


### PR DESCRIPTION
## Summary

Set rows used fixed-width columns (36 / 72 / 56 / 44pt) that clipped at AX1 and overflowed iPhone SE width by AX3. Honors PRODUCT.md's commitment to Dynamic Type at every size (xSmall through AX5) by switching to a vertical layout at accessibility sizes.

Closes #14.

## Changes

### `ExerciseLogCard`
- Reads `@Environment(\.dynamicTypeSize)`.
- The compact column header (`SET / PREV / LBS / REPS`) is hidden at AX size — the inline per-field labels in the new accessibility row carry the labeling.

### `SetLogRow`
- Reads `@Environment(\.dynamicTypeSize)`. Body switches between `mainRow` (existing tabular `HStack`) at default sizes and a new `accessibilityRow` at `.accessibility1` and above.
- `accessibilityRow` is a `VStack` with three sections:
  1. **Top row** — set-number toggle on the left, completion checkmark on the right.
  2. **"Last: …" line** — only rendered when previous-session data exists.
  3. **Labeled field pair** — `Weight` and `Reps` fields with inline caption labels above each, filling horizontally via `.frame(maxWidth: .infinity)`.
- Field components (`weightField`, `repsField`) no longer bake in their own widths. `mainRow` applies `.frame(width: 72)` and `.frame(width: 56)` at the call site; `accessibilityRow` lets them grow.
- The RIR selector splits into:
  - `compactRIRSelector` — existing inline chips for default sizes.
  - `accessibilityRIRSelector` — vertical layout with the chips wrapped in a horizontal `ScrollView` so they don't overflow iPhone SE width when each chip's hit area scales past 60pt at AX5.

## Out of scope (covered by later issues)

- `LiftTheme` token consistency → #15
- DESIGN.md `ultraThinMaterial` reconciliation → #16

## Test plan

**Build verification:**
- [x] `xcodebuild build` → BUILD SUCCEEDED
- [x] `xcodebuild test` → 23/23 tests pass in 5 suites (no view-level tests, but business-logic tests confirm no regressions)

**Simulator — Dynamic Type slider:**

In the simulator, open Settings → Accessibility → Display & Text Size → Larger Text → enable Larger Accessibility Sizes if needed → drag the slider through each step. Then return to LiftOS and open an active workout. Expand an exercise card.

- [ ] **xSmall and Large (default)** — set row looks identical to before. Column header `SET / PREV / LBS / REPS` visible. Tabular layout intact.
- [ ] **xxxLarge** — type is bigger but still tabular. No clipping, no horizontal overflow.
- [ ] **AX1** — layout switches to vertical. Set number + checkmark on top row, "Last: …" line below if applicable, Weight/Reps fields stacked side-by-side at full width. Column header is gone.
- [ ] **AX3** — same vertical layout, larger text, still readable. No horizontal overflow on iPhone SE width (375pt content width to test).
- [ ] **AX5** — extreme size. Vertical layout still holds together. Each set row takes more screen height, which is correct.
- [ ] At AX1+, complete a set → RIR selector appears with chips in a horizontal ScrollView (swipe to scroll if they overflow). Close button is at the top right of the RIR row.

**Physical device — VoiceOver at AX5:**
- [ ] With VoiceOver on at AX5, navigate a set row element-by-element. Reading order should be: set number, "Last: …" if present, "Weight" label, weight value, "Reps" label, reps value, completion button. No "checkmark" announced from a hidden column header.
- [ ] Rotor → "Actions" still exposes Mark complete / Toggle warmup / Delete set.

**Regression — sighted-user paths at default size:**
- [ ] Open an exercise card, look at a set row. Visually identical to the merged a11y/perf state. Same column widths, same tap targets, same animations.
- [ ] Tap a set checkmark → bounce, flash, RIR slide-in still work.
- [ ] Swipe a row → trash button still reveals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)