### PR TITLE
fix(workout): rewrite discard dialog copy and Cancel role

### DIFF
--- a/LiftOS/Views/Workout/ActiveWorkoutView.swift
+++ b/LiftOS/Views/Workout/ActiveWorkoutView.swift
@@ -82,7 +82,7 @@ struct ActiveWorkoutView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button("Cancel", role: .destructive) {
+                Button("Cancel") {
                     showDiscardConfirmation = true
                 }
                 .disabled(editMode.isEditing)
@@ -148,17 +148,17 @@ struct ActiveWorkoutView: View {
             let total = session.totalSets
             Text("You've completed \(completed) of \(total) sets. Save this workout?")
         }
-        .confirmationDialog("End Workout?", isPresented: $showDiscardConfirmation) {
-            Button("Discard Workout", role: .destructive) {
-                modelContext.delete(session)
+        .confirmationDialog("Leave Workout?", isPresented: $showDiscardConfirmation) {
+            Button("Save and Exit") {
                 dismiss()
             }
-            Button("Keep as In-Progress") {
+            Button("Discard", role: .destructive) {
+                modelContext.delete(session)
                 dismiss()
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("You can resume this workout later or discard it.")
+            Text("Your progress is saved. Resume from Today when you're ready.")
         }
         .task {
             refreshPreviousSets()


### PR DESCRIPTION
## Summary
- Rewrite the discard-confirmation dialog in lifter vocabulary: title `Leave Workout?`, default `Save and Exit`, destructive `Discard`, message `Your progress is saved. Resume from Today when you're ready.`
- Drop `role: .destructive` from the toolbar Cancel button so it renders default tint instead of red.
- Three-branch behavior preserved (delete-and-dismiss, save-and-dismiss, no-op).

## Test plan
- [ ] Build succeeds (verified via xcodebuild on LiftOS scheme).
- [ ] Toolbar Cancel renders in default tint, not red.
- [ ] Tapping Cancel opens the new dialog with title \"Leave Workout?\" and message \"Your progress is saved. Resume from Today when you're ready.\"
- [ ] \"Save and Exit\" dismisses without deleting the session; the workout shows as in-progress under Today.
- [ ] \"Discard\" deletes the session and dismisses.
- [ ] \"Cancel\" is a no-op and dismisses the dialog.

Closes #23